### PR TITLE
Fix the archive projects functionality

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "actiontext", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
   <%= favicon_link_tag asset_path('loading.png') %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
   <%= Sentry.get_trace_propagation_meta.html_safe %>

--- a/db/migrate/20250811134427_add_archive_status_to_products.rb
+++ b/db/migrate/20250811134427_add_archive_status_to_products.rb
@@ -1,0 +1,5 @@
+class AddArchiveStatusToProducts < ActiveRecord::Migration[7.2]
+  def change
+     add_column :products, :archive_status, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_07_094641) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_11_134427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -300,6 +300,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_07_094641) do
     t.text "document_name"
     t.string "status", default: "draft"
     t.integer "budget"
+    t.boolean "archive_status", default: false, null: false
     t.index ["client_id"], name: "index_products_on_client_id"
     t.index ["groupware_id"], name: "index_products_on_groupware_id"
     t.index ["script_id"], name: "index_products_on_script_id"


### PR DESCRIPTION
This pull request introduces a new `archive_status` field to the `products` table to track whether a product is archived. It also updates the database schema and includes some duplicated stylesheet link tags in the application layout.

**Database changes:**

* Added a migration (`db/migrate/20250811134427_add_archive_status_to_products.rb`) to include a new boolean column `archive_status` in the `products` table, with a default value of `false` and `null: false` constraint.
* Updated `db/schema.rb` to reflect the new migration and schema change, including the `archive_status` field in the `products` table. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R303)

**View changes:**

* Added multiple duplicate `stylesheet_link_tag` entries for `"tailwind"` and `"inter-font"` in `app/views/layouts/application.html.erb`, which may be unintentional and could be cleaned up.