### PR TITLE
Archive project

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = {
     host: ENV.fetch("APP_HOST", "172.16.2.15"), # host ONLY
-    protocol: ENV.fetch("APP_PROTOCOL", "http")
+    protocol: "http"
   }
   config.action_mailer.delivery_method = :smtp
 
@@ -72,6 +72,8 @@ Rails.application.configure do
 
   # allowed hosts (NO scheme)
   config.hosts << ENV.fetch("APP_HOST", "172.16.2.15")
+  config.ssl_options = { redirect: false, hsts: false }
+  config.middleware.delete ActionDispatch::SSL rescue nil
   # config.hosts << /.*\.craftsilicon\.com/
 
   # i18n / deprecations / schema dumps

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -15,6 +15,8 @@ Rails.application.configure do
   config.assets.digest = true
   # config.public_file_server.enabled = true  # uncomment if Rails must serve /public
 
+    config.force_ssl = false
+
   # storage
   config.active_storage.service = :staging
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,4 +1,3 @@
-# config/environments/staging.rb
 require "active_support/core_ext/integer/time"
 require_relative "production"
 
@@ -15,8 +14,6 @@ Rails.application.configure do
   config.assets.digest = true
   # config.public_file_server.enabled = true  # uncomment if Rails must serve /public
 
-    config.force_ssl = false
-
   # storage
   config.active_storage.service = :staging
 
@@ -29,23 +26,25 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   config.active_job.queue_name_prefix = "cspm_staging"
 
- # mailer
-config.action_mailer.perform_caching = false
-config.action_mailer.raise_delivery_errors = true
-config.action_mailer.perform_deliveries = true
-config.action_mailer.default_url_options = {
-  host: ENV.fetch("APP_HOST", "172.16.2.15"),
-  protocol: ENV.fetch("APP_PROTOCOL", "http")
-}
-config.action_mailer.delivery_method = :smtp
+  # mailer
+  config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "172.16.2.15"), # host ONLY
+    protocol: ENV.fetch("APP_PROTOCOL", "http")
+  }
+  config.action_mailer.delivery_method = :smtp
 
-if ENV["SMTP_USERNAME"].present? && ENV["SMTP_PASSWORD"].present?
+  # Choose ONE of the two blocks below:
+
+  # --- If using implicit TLS on 465 ---
   config.action_mailer.smtp_settings = {
     address:              ENV.fetch("SMTP_ADDRESS", "secure.emailsrvr.com"),
     port:                 ENV.fetch("SMTP_PORT", "465").to_i,
     domain:               ENV.fetch("SMTP_DOMAIN", "craftsilicon.com"),
-    user_name:            ENV["SMTP_USERNAME"],
-    password:             ENV["SMTP_PASSWORD"],
+    user_name:            ENV.fetch("SMTP_USERNAME"),
+    password:             ENV.fetch("SMTP_PASSWORD"),
     authentication:       :plain,
     ssl:                  true,
     enable_starttls_auto: false,
@@ -53,4 +52,30 @@ if ENV["SMTP_USERNAME"].present? && ENV["SMTP_PASSWORD"].present?
     open_timeout:         30,
     read_timeout:         30
   }
-end
+
+  # --- If using STARTTLS on 587 (use this instead, and remove the block above) ---
+  # config.action_mailer.smtp_settings = {
+  #   address:              ENV.fetch("SMTP_ADDRESS", "secure.emailsrvr.com"),
+  #   port:                 ENV.fetch("SMTP_PORT", "587").to_i,
+  #   domain:               ENV.fetch("SMTP_DOMAIN", "craftsilicon.com"),
+  #   user_name:            ENV.fetch("SMTP_USERNAME"),
+  #   password:             ENV.fetch("SMTP_PASSWORD"),
+  #   authentication:       :plain,
+  #   enable_starttls_auto: true,
+  #   open_timeout:         30,
+  #   read_timeout:         30
+  # }
+
+  # security / SSL
+  config.force_ssl = false
+  # config.assume_ssl = true # if behind SSL-terminating proxy but you access via http internally
+
+  # allowed hosts (NO scheme)
+  config.hosts << ENV.fetch("APP_HOST", "172.16.2.15")
+  # config.hosts << /.*\.craftsilicon\.com/
+
+  # i18n / deprecations / schema dumps
+  config.i18n.fallbacks = true
+  config.active_support.report_deprecations = false
+  config.active_record.dump_schema_after_migration = false
+end 


### PR DESCRIPTION
This pull request updates the `config/environments/staging.rb` file to improve mailer configuration, clarify SSL settings, and enhance environment-specific options for the staging environment. The main changes include explicit configuration for SMTP settings (with guidance for TLS vs STARTTLS), updated host and protocol handling, and adjustments to SSL and allowed hosts settings.

**Mailer configuration improvements:**

* Updated `action_mailer.smtp_settings` to use `ENV.fetch` for `SMTP_USERNAME` and `SMTP_PASSWORD`, and clarified configuration for implicit TLS (port 465) and STARTTLS (port 587), with clear comments guiding which block to use.

**SSL and host configuration:**

* Added explicit settings for SSL, including `config.force_ssl = false`, options for SSL proxies, and settings for allowed hosts without schemes. Also disables HSTS and removes the SSL middleware for staging.

**General environment tweaks:**

* Enabled i18n fallbacks, disabled deprecation reporting, and prevented schema dumps after migrations to better suit the staging environment.