### PR TITLE
Refactor `DefectController` update action for clarity, add `qa_module…

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -65,39 +65,37 @@ class DefectController < ApplicationController
     @qa_modules = QaModule.where(parent_id: nil)
     @banking_types = BankingType.all
     @users = User.with_agent_project_manager_role.order(:first_name, :last_name)
-    
+
     # Load submodules for the current module if exists
     @submodules = @defect.qa_module ? @defect.qa_module.submodules : []
   end
 
   def update
-  audit_on_update(@defect)
+    audit_on_update(@defect)
 
-  # Collect files from either place (prefer model-scoped)
-  files = []
-  files += Array(params.dig(:defect, :attachments)).reject(&:blank?) if params.dig(:defect, :attachments).present?
-  files += Array(params[:attachments]).reject(&:blank?) if params[:attachments].present?
+    # Collect files from either place (prefer model-scoped)
+    files = []
+    files += Array(params.dig(:defect, :attachments)).reject(&:blank?) if params.dig(:defect, :attachments).present?
+    files += Array(params[:attachments]).reject(&:blank?) if params[:attachments].present?
 
-  files.each { |file| @defect.attachments.attach(file) } if files.any?
+    files.each { |file| @defect.attachments.attach(file) } if files.any?
 
-  if @defect.update(defect_params)
-    activity('user_activity')
-      .caused_by(current_user)
-      .performed_on(@defect)
-      .event('defect.update')
-      .with_properties(
-        defect_id: @defect.id,
-        qa_module_id: @defect.qa_module_id # optional, only if you want this info
-      )
-      .log("Updated Defect ##{@defect.id}")
+    if @defect.update(defect_params)
+      activity('user_activity')
+        .caused_by(current_user)
+        .performed_on(@defect)
+        .event('defect.update')
+        .with_properties(
+          defect_id: @defect.id,
+          qa_module_id: @defect.qa_module_id # optional, only if you want this info
+        )
+        .log("Updated Defect ##{@defect.id}")
 
-    redirect_to @defect, notice: 'Defect was successfully updated.'
-  else
-    render :edit
+      redirect_to @defect, notice: 'Defect was successfully updated.'
+    else
+      render :edit
+    end
   end
-end
-
-
 
   def destroy
     if audit_soft_delete(@defect)

--- a/db/migrate/20250814072950_create_qa_modules.rb
+++ b/db/migrate/20250814072950_create_qa_modules.rb
@@ -1,0 +1,11 @@
+class CreateQaModules < ActiveRecord::Migration[7.2]
+  def change
+    create_table :qa_modules, id: :uuid do |t|
+      t.string :name
+      t.uuid :parent_id
+
+      t.timestamps
+    end
+    add_index :qa_modules, :parent_id
+  end
+end

--- a/db/migrate/20250818119320_drop_banking_type_table.rb
+++ b/db/migrate/20250818119320_drop_banking_type_table.rb
@@ -1,0 +1,5 @@
+class DropBankingTypeTable < ActiveRecord::Migration[7.2]
+  def change
+    drop_table :banking_types
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,14 +130,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_19_064138) do
   end
 
   create_table "banking_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "created_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da", null: false
-    t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da", null: false
-    t.uuid "deleted_by"
-    t.datetime "deleted_on"
-    t.index ["deleted_on"], name: "index_banking_types_on_deleted_on"
+    t.index ["name"], name: "index_banking_types_on_name", unique: true
   end
 
   create_table "boards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -536,6 +532,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_19_064138) do
     t.index ["software_id", "project_id"], name: "index_projects_softwares_on_software_id_and_project_id", unique: true
   end
 
+  create_table "qa_modules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.uuid "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_qa_modules_on_parent_id"
+  end
+
   create_table "ratings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "value"
     t.uuid "ticket_id", null: false
@@ -826,6 +830,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_19_064138) do
     t.uuid "client_id"
     t.boolean "active", default: true
     t.uuid "location_id"
+    t.string "position"
     t.uuid "created_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da", null: false
     t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da", null: false
     t.uuid "deleted_by"


### PR DESCRIPTION
…s` table migration, and remove `banking_types` table and related schema updates.
This pull request introduces significant updates to the database schema and related migrations, including the addition of a new table, removal of an obsolete table, and some schema adjustments. The changes are grouped below by theme.

**Database schema changes:**

* Added a new `qa_modules` table with a `name`, `parent_id`, and timestamp columns, including an index on `parent_id`. (`db/migrate/20250814072950_create_qa_modules.rb`, `db/schema.rb`) [[1]](diffhunk://#diff-0ba986d5e1e8993110fa2d9648a044e0565305d7772fb5d1feaff5f9c2899dccR1-R11) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R535-R542)
* Dropped the `banking_types` table via a migration. (`db/migrate/20250818119320_drop_banking_type_table.rb`)
* Updated the schema for `banking_types` to make the `name` field non-nullable and added a unique index on `name`; removed several columns and the index on `deleted_on`. (`db/schema.rb`)
* Added a new `position` string column to the `users` table. (`db/schema.rb`)

**Controller cleanup:**

* Removed unnecessary blank lines from the `update` method in `app/controllers/defect_controller.rb`.