### PR TITLE
Banking fix types

### DIFF
--- a/db/migrate/20250818119321_create_banking_types.rb
+++ b/db/migrate/20250818119321_create_banking_types.rb
@@ -4,6 +4,6 @@ class CreateBankingTypes < ActiveRecord::Migration[7.2]
       t.string :name, null: false
       t.timestamps
     end
-    add_index :banking_types, :name, unique: true
+    add_index :banking_types, :name, unique: true, if_not_exists: true
   end
 end

--- a/db/migrate/20250818119321_create_banking_types.rb
+++ b/db/migrate/20250818119321_create_banking_types.rb
@@ -1,6 +1,6 @@
 class CreateBankingTypes < ActiveRecord::Migration[7.2]
   def change
-    create_table :banking_types, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+    create_table :banking_types, id: :uuid, default: -> { "gen_random_uuid()" }, if_not_exists: true do |t|
       t.string :name, null: false
       t.timestamps
     end


### PR DESCRIPTION
This pull request makes small improvements to the migration for the `banking_types` table. The changes ensure that the table and its index are only created if they do not already exist, which helps prevent migration errors during repeated runs.
