### PR TITLE
Unique defect

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -195,6 +195,7 @@ class DefectController < ApplicationController
       :priority,
       :product_id,
       :status_id,
+      :defect_unique,
       user_ids: [],
       attachments: []
     )

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -47,9 +47,9 @@ class Defect < ApplicationRecord
 
     last_defect =
       Defect.where(product_id: product_id)
-            .where("defect_unique ~ '^[^-]+-\\d+$'")
-            .order(Arel.sql("CAST(SPLIT_PART(defect_unique, '-', 2) AS INTEGER) DESC"))
-            .first ||
+        .where("defect_unique ~ '^[^-]+-\\d+$'")
+        .order(Arel.sql("CAST(SPLIT_PART(defect_unique, '-', 2) AS INTEGER) DESC"))
+        .first ||
       Defect.where(product_id: product_id).order(:created_at).last
 
     next_number =
@@ -62,6 +62,7 @@ class Defect < ApplicationRecord
     loop do
       self.defect_unique = "#{initials}-#{next_number.to_s.rjust(4, '0')}"
       break unless Defect.exists?(defect_unique: defect_unique)
+
       next_number += 1
     end
 

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -29,10 +29,42 @@ class Defect < ApplicationRecord
   end
 
   before_validation :set_default_status, on: :create
+  after_create :defect_unique_id
 
   private
 
   def set_default_status
     self.status ||= Status.find_by(name: 'TO DO')
+  end
+
+  def defect_unique_id
+    initials =
+      if product&.client&.name.present?
+        product.client.name.split.map { |word| word[0] }.join.upcase
+      else
+        'DEFAULT'
+      end
+
+    last_defect =
+      Defect.where(product_id: product_id)
+            .where("defect_unique ~ '^[^-]+-\\d+$'")
+            .order(Arel.sql("CAST(SPLIT_PART(defect_unique, '-', 2) AS INTEGER) DESC"))
+            .first ||
+      Defect.where(product_id: product_id).order(:created_at).last
+
+    next_number =
+      if last_defect&.defect_unique.present?
+        last_defect.unique_id.split('-').last.to_i + 1
+      else
+        1
+      end
+
+    loop do
+      self.defect_unique = "#{initials}-#{next_number.to_s.rjust(4, '0')}"
+      break unless Defect.exists?(defect_unique: defect_unique)
+      next_number += 1
+    end
+
+    save
   end
 end

--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -17,7 +17,9 @@
         <% @defects.each do |defect| %>
           <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-left" style="cursor:pointer;" onclick="window.location='<%= defect_path(defect.id) %>'">
             <td class="px-6 py-4">
-              <%= defect.summary.truncate(30) %>
+              <% if defect.summary.present? %>
+                <%= defect.summary.truncate(30) %>
+              <% end %>
             </td>
             <td class="px-6 py-4">
               <%= defect.qa_module&.name || 'N/A' %>
@@ -28,7 +30,7 @@
               </span>
             </td>
             <td class="px-6 py-4">
-              <%= defect.status.name %>
+              <%#= defect.status.name %>
             </td>
             <td class="px-6 py-4">
               <%= User.find_by(id: defect.creator_id)&.first_name || 'Unknown' %>

--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -2,6 +2,8 @@
   <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
     <thead class="text-xs uppercase bg-gray-200 dark:bg-gray-700 dark:text-gray-400 w-[100%]">
       <tr>
+        <th scope="col" class="px-6 py-3">Defect ID</th>
+
         <th scope="col" class="px-6 py-3">Summary</th>
         <th scope="col" class="px-6 py-3">Module</th>
         <th scope="col" class="px-6 py-3">Priority</th>
@@ -16,6 +18,9 @@
       <% if @defects.present? %>
         <% @defects.each do |defect| %>
           <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-left" style="cursor:pointer;" onclick="window.location='<%= defect_path(defect.id) %>'">
+            <td class="px-6 py-4">
+                <%= defect.defect_unique %>
+            </td>
             <td class="px-6 py-4">
               <% if defect.summary.present? %>
                 <%= defect.summary.truncate(30) %>

--- a/app/views/defect/show.html.erb
+++ b/app/views/defect/show.html.erb
@@ -61,7 +61,7 @@
         <div>
           <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400">Status</h3>
           <div class="mt-1 text-gray-900 dark:text-white">
-            <%= @defect.status.name %>
+            <%#= @defect.status.name %>
           </div>
         </div>
         

--- a/db/migrate/20250820100042_update_defects_table.rb
+++ b/db/migrate/20250820100042_update_defects_table.rb
@@ -1,7 +1,7 @@
 class UpdateDefectsTable < ActiveRecord::Migration[7.2]
   def change
     add_reference :defects, :product, type: :uuid, foreign_key: true, index: true
-    add_column :defects, :summary, :string, null: false
+    add_column :defects, :summary, :string, null: true
     remove_column :defects, :status, :string
     add_reference :defects, :status, type: :uuid, foreign_key: true, index: true
   end

--- a/db/migrate/20250820122834_add_defect_unique_to_defect.rb
+++ b/db/migrate/20250820122834_add_defect_unique_to_defect.rb
@@ -1,0 +1,7 @@
+class AddDefectUniqueToDefect < ActiveRecord::Migration[7.2]
+  def change
+    add_column :defects, :defect_unique, :string
+    add_index :defects, :defect_unique, unique: true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_20_100042) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_20_122834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -218,10 +218,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_20_100042) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary", null: false
+    t.string "summary"
     t.uuid "status_id"
+    t.string "defect_unique"
     t.index ["banking_type_id"], name: "index_defects_on_banking_type_id"
     t.index ["creator_id"], name: "index_defects_on_creator_id"
+    t.index ["defect_unique"], name: "index_defects_on_defect_unique", unique: true
     t.index ["deleted_on"], name: "index_defects_on_deleted_on"
     t.index ["product_id"], name: "index_defects_on_product_id"
     t.index ["qa_module_id"], name: "index_defects_on_qa_module_id"


### PR DESCRIPTION
This pull request introduces a unique identifier (`defect_unique`) for each defect, automates its generation, and updates the database and UI to support and display this new value. It also makes the `summary` field optional and temporarily hides the defect status from the UI.

### Unique Defect ID Implementation

* Added a new `defect_unique` string column to the `defects` table, enforced uniqueness with a database index, and updated the schema accordingly. [[1]](diffhunk://#diff-e10907144ea64b40ffb31c717488f3103f6befe55e70005b5111d6dc3c31ca91R1-R7) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L221-R226)
* Implemented an `after_create` callback in the `Defect` model to automatically generate a unique defect ID based on the client initials and an incrementing number.
* Updated strong parameters in the `DefectController` to permit the new `defect_unique` field.

### UI Changes

* Modified the defects list partial (`_defect.html.erb`) to display the new defect ID and ensure summaries are shown only if present. [[1]](diffhunk://#diff-1802878bf2bfd0b78ac30fbffb3556f212d31d68b908bad197230fdf5effb36aR5-R6) [[2]](diffhunk://#diff-1802878bf2bfd0b78ac30fbffb3556f212d31d68b908bad197230fdf5effb36aR22-R27)
* Temporarily commented out the display of defect status in both the list and show views. [[1]](diffhunk://#diff-1802878bf2bfd0b78ac30fbffb3556f212d31d68b908bad197230fdf5effb36aL31-R38) [[2]](diffhunk://#diff-c32c38ace09876f3fe73d89d97a6126017a99aeb3ba6b69b5a9ad264a6a30b34L64-R64)

### Database Migration Updates

* Made the `summary` field nullable in the defects table migration and reflected this change in the schema. [[1]](diffhunk://#diff-f848c1a9fce1403c4cbe7bfbf9f41ca052af1c0fe93d540c0e99450c7994eb9aL4-R4) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L221-R226)