### PR TITLE
Fix defect ID generation logic and clean up defect listing table layout.

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -54,7 +54,7 @@ class Defect < ApplicationRecord
 
     next_number =
       if last_defect&.defect_unique.present?
-        last_defect.unique_id.split('-').last.to_i + 1
+        last_defect.defect_unique.split('-').last.to_i + 1
       else
         1
       end

--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -5,10 +5,7 @@
         <th scope="col" class="px-6 py-3">Defect ID</th>
 
         <th scope="col" class="px-6 py-3">Summary</th>
-        <th scope="col" class="px-6 py-3">Module</th>
         <th scope="col" class="px-6 py-3">Priority</th>
-        <th scope="col" class="px-6 py-3">Status</th>
-        <th scope="col" class="px-6 py-3">Reporter</th>
         <th scope="col" class="px-6 py-3">Assignee(s)</th>
         <th scope="col" class="px-6 py-3">Created At</th>
         <th scope="col" class="px-6 py-3">Actions</th>
@@ -27,24 +24,27 @@
               <% end %>
             </td>
             <td class="px-6 py-4">
-              <%= defect.qa_module&.name || 'N/A' %>
-            </td>
-            <td class="px-6 py-4">
               <span class="px-2 py-1 text-xs font-medium rounded <%= priority_badge_class(defect.priority) %>">
                 <%= defect.priority %>
               </span>
             </td>
             <td class="px-6 py-4">
-              <%#= defect.status.name %>
-            </td>
-            <td class="px-6 py-4">
               <%= User.find_by(id: defect.creator_id)&.first_name || 'Unknown' %>
             </td>
             <td class="px-6 py-4">
-              <%= defect.users.map(&:first_name).join(', ') || 'Unassigned' %>
+              <%= defect.users.map { |u| [u.first_name, u.last_name].compact.join(' ') }
+                        .reject(&:blank?)
+                        .join(', ')
+                        .presence || 'Unassigned' %>
             </td>
             <td class="px-6 py-4">
-              <%= defect.created_at.strftime('%Y-%m-%d') %>
+              <div class="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                  <path d="M12 11.993a.75.75 0 0 0-.75.75v.006c0 .414.336.75.75.75h.006a.75.75 0 0 0 .75-.75v-.006a.75.75 0 0 0-.75-.75H12ZM12 16.494a.75.75 0 0 0-.75.75v.005c0 .414.335.75.75.75h.005a.75.75 0 0 0 .75-.75v-.005a.75.75 0 0 0-.75-.75H12ZM8.999 17.244a.75.75 0 0 1 .75-.75h.006a.75.75 0 0 1 .75.75v.006a.75.75 0 0 1-.75.75h-.006a.75.75 0 0 1-.75-.75v-.006ZM7.499 16.494a.75.75 0 0 0-.75.75v.005c0 .414.336.75.75.75h.005a.75.75 0 0 0 .75-.75v-.005a.75.75 0 0 0-.75-.75H7.5ZM13.499 14.997a.75.75 0 0 1 .75-.75h.006a.75.75 0 0 1 .75.75v.005a.75.75 0 0 1-.75.75h-.006a.75.75 0 0 1-.75-.75v-.005ZM14.25 16.494a.75.75 0 0 0-.75.75v.006c0 .414.335.75.75.75h.005a.75.75 0 0 0 .75-.75v-.006a.75.75 0 0 0-.75-.75h-.005ZM15.75 14.995a.75.75 0 0 1 .75-.75h.005a.75.75 0 0 1 .75.75v.006a.75.75 0 0 1-.75.75H16.5a.75.75 0 0 1-.75-.75v-.006ZM13.498 12.743a.75.75 0 0 1 .75-.75h2.25a.75.75 0 1 1 0 1.5h-2.25a.75.75 0 0 1-.75-.75ZM6.748 14.993a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Z" />
+                  <path fill-rule="evenodd" d="M18 2.993a.75.75 0 0 0-1.5 0v1.5h-9V2.994a.75.75 0 1 0-1.5 0v1.497h-.752a3 3 0 0 0-3 3v11.252a3 3 0 0 0 3 3h13.5a3 3 0 0 0 3-3V7.492a3 3 0 0 0-3-3H18V2.993ZM3.748 18.743v-7.5a1.5 1.5 0 0 1 1.5-1.5h13.5a1.5 1.5 0 0 1 1.5 1.5v7.5a1.5 1.5 0 0 1-1.5 1.5h-13.5a1.5 1.5 0 0 1-1.5-1.5Z" clip-rule="evenodd" />
+                </svg>
+                <%= defect.created_at.strftime('%d-%m-%Y') %>
+              </div>
             </td>
             <td class="px-6 py-4 text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= defect.id %>">
               <div class="relative w-full flex justify-start">


### PR DESCRIPTION
This pull request refines the defect list view and corrects a minor bug in the defect unique ID generation. The most significant changes are the removal of unused columns in the defect table, improvements to how assignees are displayed, and an update to the date formatting with a calendar icon for better visual clarity.

**Defect Table View Improvements:**

* Removed the `Module`, `Status`, and `Reporter` columns from the defect list table to simplify the view.
* Updated the assignees display to show both first and last names, and improved handling for unassigned defects.
* Enhanced the created date column by adding a calendar icon and changing the date format to `dd-mm-yyyy` for better readability.

**Bug Fix:**

* Fixed a bug in the `defect_unique_id` method by using the correct attribute (`defect_unique`) when calculating the next defect ID, instead of the incorrect `unique_id`.