### PR TITLE
Make `summary` optional and adjust defect view for improved readability.

### DIFF
--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -4,7 +4,7 @@
       <tr>
         <th scope="col" class="px-6 py-3">Defect ID</th>
 
-        <th scope="col" class="px-6 py-3">Summary</th>
+        <th scope="col" class="px-6 py-3 w-1/3">Summary</th>
         <th scope="col" class="px-6 py-3">Priority</th>
         <th scope="col" class="px-6 py-3">Assignee(s)</th>
         <th scope="col" class="px-6 py-3">Created At</th>
@@ -21,7 +21,7 @@
             </td>
             <td class="px-6 py-4">
               <% if defect.summary.present? %>
-                <%= defect.summary.truncate(30) %>
+                <%= defect.summary.truncate(70) %>
               <% end %>
             </td>
             <td class="px-6 py-4">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -232,7 +232,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_21_120959) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary", null: false
+    t.string "summary"
     t.string "defect_unique"
     t.index ["banking_type_id"], name: "index_defects_on_banking_type_id"
     t.index ["creator_id"], name: "index_defects_on_creator_id"


### PR DESCRIPTION
This pull request makes improvements to the defect summary display and updates the schema for defect records. The most important changes include increasing the visible length of defect summaries in the UI and making the `summary` field optional in the database.

**UI improvements:**

* Increased the width of the `Summary` column in the defect table by adding the `w-1/3` class to improve readability.
* Increased the truncation limit for defect summaries from 30 to 70 characters, allowing more of the summary to be visible in the UI.

**Database schema update:**

* Made the `summary` field optional (removed `null: false` constraint) in the `defects` table to allow defect records without a summary.