### PR TITLE
Timeline fixed down

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -643,6 +643,23 @@ class DataCenterController < ApplicationController
     @issues = @issues.where(created_at: from_time..to_time) if from_time || to_time
     @issues = @issues.includes(:ticket).to_a
 
+    # Average time from assignment to resolution across resolved tickets
+    durations = []
+    @tickets.each do |t|
+      a = assigned_at_for(t)
+      r = resolved_at_for(t)
+      durations << (r - a).to_i if a && r
+    end
+    @avg_assignment_to_resolved_count = durations.size
+    if durations.any?
+      avg_seconds = (durations.sum / durations.size.to_f).round
+      @avg_assignment_to_resolved_seconds = avg_seconds
+      @avg_assignment_to_resolved_human = helpers.distance_of_time_in_words(Time.at(0), Time.at(avg_seconds), include_seconds: true)
+    else
+      @avg_assignment_to_resolved_seconds = nil
+      @avg_assignment_to_resolved_human = nil
+    end
+
     respond_to do |format|
       format.html
       format.csv { send_data generate_user_csv(@users), filename: "user_report_#{Date.today}.csv" }

--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -60,10 +60,10 @@ class DefectController < ApplicationController
     @banking_types = BankingType.all
     @products = Product.with_quality_assurance_status
     @statuses = Status.where(name: [
-      'To Do', 'In Progress', 'On hold', 'Awaiting client info', 
-      'Awaiting build', 'QA testing', 'Closed', 'Failed QA', 
-      'Blocked', 'Reopened'
-    ])
+                               'To Do', 'In Progress', 'On hold', 'Awaiting client info',
+                               'Awaiting build', 'QA testing', 'Closed', 'Failed QA',
+                               'Blocked', 'Reopened'
+                             ])
     @users = User.with_agent_project_manager_role.order(:first_name, :last_name)
     @submodules = @defect.qa_module ? @defect.qa_module.submodules : []
 
@@ -72,7 +72,6 @@ class DefectController < ApplicationController
       format.turbo_stream { render layout: false } # only return the turbo frame
     end
   end
-
 
   def update
     audit_on_update(@defect)
@@ -202,24 +201,24 @@ class DefectController < ApplicationController
     @banking_types = BankingType.all
     @users = User.with_agent_project_manager_role.order(:first_name, :last_name)
     @submodules = []
-     # Fallback: If no QA product found, just pick first product
+    # Fallback: If no QA product found, just pick first product
     @product ||= Product.includes(:client, :groupwares).first
 
     # Dropdown options for product selection
     @products_and_clients_defects = Product.includes(:client, :groupwares, :statuses)
       .select { |product| product.statuses.any? { |status| status.name == 'Quality Assurance' } }
       .map do |product|
-        client_name = product.client&.name || 'No Client'
-        groupware_names = product.groupwares.any? ? product.groupwares.map(&:name).join(', ') : 'No Software'
-        ["#{client_name} - #{groupware_names}", product.id]
+      client_name = product.client&.name || 'No Client'
+      groupware_names = product.groupwares.any? ? product.groupwares.map(&:name).join(', ') : 'No Software'
+      ["#{client_name} - #{groupware_names}", product.id]
     end
-    
+
     # Get all available statuses for the workflow
     @statuses = Status.where(name: [
-      'To Do', 'In Progress', 'On hold', 'Awaiting client info', 
-      'Awaiting build', 'QA testing', 'Closed', 'Failed QA', 
-      'Blocked', 'Reopened'
-    ])
+                               'To Do', 'In Progress', 'On hold', 'Awaiting client info',
+                               'Awaiting build', 'QA testing', 'Closed', 'Failed QA',
+                               'Blocked', 'Reopened'
+                             ])
   end
 
   def set_defect

--- a/app/views/data_center/user_report.html.erb
+++ b/app/views/data_center/user_report.html.erb
@@ -161,6 +161,21 @@
           </tr>
         <% end %>
         </tbody>
+
+        <!-- Average row in the table footer -->
+        <tfoot>
+        <tr>
+          <td colspan="6" class="border border-black dark:border-slate-100 px-4 py-2 font-semibold bg-gray-50 dark:bg-gray-800">
+            <% if @avg_assignment_to_resolved_seconds %>
+              Average time from assignment to resolution across
+              <%= pluralize(@avg_assignment_to_resolved_count, 'ticket') %>:
+              <%= @avg_assignment_to_resolved_human %>
+            <% else %>
+              No resolved tickets with an assignment time to compute an average.
+            <% end %>
+          </td>
+        </tr>
+        </tfoot>
       </table>
     <% else %>
       <p class="text-sm text-gray-600">No assignment events found for the selected criteria.</p>

--- a/app/views/tickets/_ticket_user_initials.html.erb
+++ b/app/views/tickets/_ticket_user_initials.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-wrap gap-2 items-center">
 
     <% if event.user.profile_picture.attached? %>
-        <%= image_tag user.profile_picture, class: 'w-10 h-10 rounded-md' %>
+        <%= image_tag event.user.profile_picture, class: 'w-10 h-10 rounded-md' %>
       <% elsif event.user.name_initials.present? %>
         <span class="w-10 h-10 inline-flex items-center px-2 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
           <%= event.user.name_initials %>

--- a/app/views/tickets/_ticket_user_initials.html.erb
+++ b/app/views/tickets/_ticket_user_initials.html.erb
@@ -1,0 +1,14 @@
+<div class="flex flex-wrap gap-2 items-center">
+
+    <% if event.user.profile_picture.attached? %>
+        <%= image_tag user.profile_picture, class: 'w-10 h-10 rounded-md' %>
+      <% elsif event.user.name_initials.present? %>
+        <span class="w-10 h-10 inline-flex items-center px-2 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+          <%= event.user.name_initials %>
+        </span>
+      <% else %>
+        <%= image_tag 'default.png', class: 'w-10 h-10 rounded-full' %>
+      <% end %>
+
+</div>
+

--- a/app/views/tickets/_timeline.html.erb
+++ b/app/views/tickets/_timeline.html.erb
@@ -28,7 +28,7 @@
             <p class="text-base font-normal text-gray-500 dark:text-gray-400"><%= event.details %></p>
           </div>
         </li>
-      <% end %>
+    <% end %>
     </ol>
   </div>
 

--- a/app/views/tickets/_timeline_down.html.erb
+++ b/app/views/tickets/_timeline_down.html.erb
@@ -1,0 +1,16 @@
+<div class="p-5 mb-4 border border-gray-100 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+  <% @events.each_with_index do |event, index| %>
+    <time class="text-lg font-semibold text-gray-900 dark:text-white"><%= event.created_at.strftime("%B %d, %Y %H:%M") %></time>
+    <ol class="mt-3 divide-y divide-gray-200 dark:divide-gray-700">
+      <li>
+        <div class="items-center block p-3 sm:flex hover:bg-gray-100 dark:hover:bg-gray-700 gap-2">
+          <%= render 'tickets/ticket_user_initials', event: event %>
+          <div class="text-gray-600 dark:text-gray-400">
+            <div class="text-base font-normal"><span class="font-medium text-gray-900 dark:text-white"><%= event.user.name %></span></div>
+            <div class="text-sm font-normal"><%= event.details %></div>
+          </div>
+        </div>
+      </li>
+    </ol>
+  <% end %>
+</div>

--- a/app/views/tickets/_timeline_down.html.erb
+++ b/app/views/tickets/_timeline_down.html.erb
@@ -1,7 +1,7 @@
 <div class="p-5 mb-4 border border-gray-100 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
-  <% @events.each_with_index do |event, index| %>
+  <% @events.each_with_index do |event| %>
     <time class="text-lg font-semibold text-gray-900 dark:text-white"><%= event.created_at.strftime("%B %d, %Y %H:%M") %></time>
-    <ol class="mt-3 divide-y divide-gray-200 dark:divide-gray-700">
+    <ol class="mt-3 divide-y divide-gray-200 dark:divide-gray-700 gap-2">
       <li>
         <div class="items-center block p-3 sm:flex hover:bg-gray-100 dark:hover:bg-gray-700 gap-2">
           <%= render 'tickets/ticket_user_initials', event: event %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -116,7 +116,7 @@
   <% end %>
   <% if current_user.has_role?(:agent) || current_user.has_role?(:admin) || current_user.has_role?('project manager') || current_user.has_role?(:observer) || current_user.has_role?(:client)%>
     <div class="w-full">
-      <%= render 'tickets/timeline' %>
+      <%= render 'tickets/timeline_down' %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
This pull request introduces improvements to ticket reporting and enhances the ticket timeline UI. The main changes include adding an average assignment-to-resolution time metric to the user report, updating the timeline display with user initials or profile pictures, and refactoring timeline rendering for better visual clarity.

**Reporting enhancements:**

* Added calculation of the average time from assignment to resolution for resolved tickets in the `user_report` controller action (`app/controllers/data_center_controller.rb`).
* Displayed the computed average assignment-to-resolution time in the user report table footer, including a human-readable format and ticket count (`app/views/data_center/user_report.html.erb`).

**Timeline UI improvements:**

* Created a new partial, `timeline_down`, for rendering ticket events with improved styling and structure, including user initials/profile pictures and event details (`app/views/tickets/_timeline_down.html.erb`).
* Updated the ticket show view to use the new `timeline_down` partial instead of the old timeline (`app/views/tickets/show.html.erb`).
* Added a reusable partial for displaying user initials or profile pictures in ticket events, with a fallback to a default image (`app/views/tickets/_ticket_user_initials.html.erb`).

**Minor code cleanup:**

* Removed an unnecessary blank line in the `edit` action of the defect controller (`app/controllers/defect_controller.rb`).