### PR TITLE
Statuses defect order

### DIFF
--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -14,50 +14,7 @@
     </thead>
     <tbody>
       <% if @defects.present? %>
-        <% @defects.each do |defect| %>
-          <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-left" style="cursor:pointer;" onclick="window.location='<%= defect_path(defect.id) %>'">
-            <td class="px-6 py-4">
-              <%= defect.defect_unique %>
-            </td>
-            <td class="px-6 py-4">
-              <% if defect.summary.present? %>
-                <%= defect.summary.truncate(50) %>
-              <% end %>
-            </td>
-            <td class="px-6 py-4 flex items-center gap-2">
-              <%= render partial: 'defect/defect_statuses', locals: { defect: defect } %>
-            </td>
-            <td class="px-6 py-4">
-              <span class="px-2 py-1 text-xs font-medium rounded <%= priority_badge_class(defect.priority) %>">
-                <%= defect.priority %>
-              </span>
-            </td>
-            <td class="px-6 py-4 flex items-center gap-2">
-              <%= render partial: 'defect/user_initials', locals: { defect: defect } %>
-              <%= defect.users.map { |u| [u.first_name, u.last_name].compact.join(' ') }
-                        .reject(&:blank?)
-                        .join(', ')
-                        .presence || 'Unassigned' %>
-            </td>
-            <td class="px-6 py-4">
-              <div class="flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
-                  <path d="M12 11.993a.75.75 0 0 0-.75.75v.006c0 .414.336.75.75.75h.006a.75.75 0 0 0 .75-.75v-.006a.75.75 0 0 0-.75-.75H12ZM12 16.494a.75.75 0 0 0-.75.75v.005c0 .414.335.75.75.75h.005a.75.75 0 0 0 .75-.75v-.005a.75.75 0 0 0-.75-.75H12ZM8.999 17.244a.75.75 0 0 1 .75-.75h.006a.75.75 0 0 1 .75.75v.006a.75.75 0 0 1-.75.75h-.006a.75.75 0 0 1-.75-.75v-.006ZM7.499 16.494a.75.75 0 0 0-.75.75v.005c0 .414.336.75.75.75h.005a.75.75 0 0 0 .75-.75v-.005a.75.75 0 0 0-.75-.75H7.5ZM13.499 14.997a.75.75 0 0 1 .75-.75h.006a.75.75 0 0 1 .75.75v.005a.75.75 0 0 1-.75.75h-.006a.75.75 0 0 1-.75-.75v-.005ZM14.25 16.494a.75.75 0 0 0-.75.75v.006c0 .414.335.75.75.75h.005a.75.75 0 0 0 .75-.75v-.006a.75.75 0 0 0-.75-.75h-.005ZM15.75 14.995a.75.75 0 0 1 .75-.75h.005a.75.75 0 0 1 .75.75v.006a.75.75 0 0 1-.75.75H16.5a.75.75 0 0 1-.75-.75v-.006ZM13.498 12.743a.75.75 0 0 1 .75-.75h2.25a.75.75 0 1 1 0 1.5h-2.25a.75.75 0 0 1-.75-.75ZM6.748 14.993a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Z" />
-                  <path fill-rule="evenodd" d="M18 2.993a.75.75 0 0 0-1.5 0v1.5h-9V2.994a.75.75 0 1 0-1.5 0v1.497h-.752a3 3 0 0 0-3 3v11.252a3 3 0 0 0 3 3h13.5a3 3 0 0 0 3-3V7.492a3 3 0 0 0-3-3H18V2.993ZM3.748 18.743v-7.5a1.5 1.5 0 0 1 1.5-1.5h13.5a1.5 1.5 0 0 1 1.5 1.5v7.5a1.5 1.5 0 0 1-1.5 1.5h-13.5a1.5 1.5 0 0 1-1.5-1.5Z" clip-rule="evenodd" />
-                </svg>
-                <%= defect.created_at.strftime('%d-%m-%Y') %>
-              </div>
-            </td>
-            <td class="px-6 py-4">
-              <%= "#{defect.product.client.name} #{defect.product.groupwares.first&.name}".truncate(30) %>
-            </td>
-            <td class="px-6 py-4 text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= defect.id %>">
-              <div class="relative w-full flex justify-start">
-                <%= render partial: 'defect/action_dropdown', locals: { defect: defect } %>
-              </div>
-            </td>
-          </tr>
-        <% end %>
+        <%= render partial: 'defect/defect_order_status' %>
       <% else %>
         <tr>
           <td class="px-6 py-4 text-center text-gray-500 dark:text-gray-400">

--- a/app/views/defect/_defect_order_status.html.erb
+++ b/app/views/defect/_defect_order_status.html.erb
@@ -1,0 +1,57 @@
+<% statuses_order = ['TO DO', 'In Progress'] %>
+<% status_groups = @defects.group_by { |d| d.statuses.first&.name } %>
+
+<% statuses_order.each do |status| %>
+  <% defects_for_status = status_groups[status]&.uniq { |defect| defect.id } || [] %>
+  <% if defects_for_status.any? %>
+    <tr>
+      <th colspan="8" class="bg-gray-100 dark:bg-gray-900 text-lg font-bold px-6 py-3 border-b border-t dark:border-gray-700">
+        <%= status %>
+      </th>
+    </tr>
+    <% defects_for_status.each do |defect| %>
+      <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-left" style="cursor:pointer;" onclick="window.location='<%= defect_path(defect.id) %>'">
+        <td class="px-6 py-4">
+          <%= defect.defect_unique %>
+        </td>
+        <td class="px-6 py-4">
+          <% if defect.summary.present? %>
+            <%= defect.summary.truncate(50) %>
+          <% end %>
+        </td>
+        <td class="px-6 py-4 flex items-center gap-2">
+          <%= render partial: 'defect/defect_statuses', locals: { defect: defect } %>
+        </td>
+        <td class="px-6 py-4">
+          <span class="px-2 py-1 text-xs font-medium rounded <%= priority_badge_class(defect.priority) %>">
+            <%= defect.priority %>
+          </span>
+        </td>
+        <td class="px-6 py-4 flex items-center gap-2">
+          <%= render partial: 'defect/user_initials', locals: { defect: defect } %>
+          <%= defect.users.map { |u| [u.first_name, u.last_name].compact.join(' ') }
+                    .reject(&:blank?)
+                    .join(', ')
+                    .presence || 'Unassigned' %>
+        </td>
+        <td class="px-6 py-4">
+          <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+              <path d="M12 11.993a.75.75 0 0 0-.75.75v.006c0 .414.336.75.75.75h.006a.75.75 0 0 0 .75-.75v-.006a.75.75 0 0 0-.75-.75H12ZM12 16.494a.75.75 0 0 0-.75.75v.005c0 .414.335.75.75.75h.005a.75.75 0 0 0 .75-.75v-.005a.75.75 0 0 0-.75-.75H12ZM8.999 17.244a.75.75 0 0 1 .75-.75h.006a.75.75 0 0 1 .75.75v.006a.75.75 0 0 1-.75.75h-.006a.75.75 0 0 1-.75-.75v-.006ZM7.499 16.494a.75.75 0 0 0-.75.75v.005c0 .414.336.75.75.75h.005a.75.75 0 0 0 .75-.75v-.005a.75.75 0 0 0-.75-.75H7.5ZM13.499 14.997a.75.75 0 0 1 .75-.75h.006a.75.75 0 0 1 .75.75v.005a.75.75 0 0 1-.75.75h-.006a.75.75 0 0 1-.75-.75v-.005ZM14.25 16.494a.75.75 0 0 0-.75.75v.006c0 .414.335.75.75.75h.005a.75.75 0 0 0 .75-.75v-.006a.75.75 0 0 0-.75-.75h-.005ZM15.75 14.995a.75.75 0 0 1 .75-.75h.005a.75.75 0 0 1 .75.75v.006a.75.75 0 0 1-.75.75H16.5a.75.75 0 0 1-.75-.75v-.006ZM13.498 12.743a.75.75 0 0 1 .75-.75h2.25a.75.75 0 1 1 0 1.5h-2.25a.75.75 0 0 1-.75-.75ZM6.748 14.993a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Z" />
+              <path fill-rule="evenodd" d="M18 2.993a.75.75 0 0 0-1.5 0v1.5h-9V2.994a.75.75 0 1 0-1.5 0v1.497h-.752a3 3 0 0 0-3 3v11.252a3 3 0 0 0 3 3h13.5a3 3 0 0 0 3-3V7.492a3 3 0 0 0-3-3H18V2.993ZM3.748 18.743v-7.5a1.5 1.5 0 0 1 1.5-1.5h13.5a1.5 1.5 0 0 1 1.5 1.5v7.5a1.5 1.5 0 0 1-1.5 1.5h-13.5a1.5 1.5 0 0 1-1.5-1.5Z" clip-rule="evenodd" />
+            </svg>
+            <%= defect.created_at.strftime('%d-%m-%Y') %>
+          </div>
+        </td>
+        <td class="px-6 py-4">
+          <%= "#{defect.product.client.name} #{defect.product.groupwares.first&.name}".truncate(30) %>
+        </td>
+        <td class="px-6 py-4 text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= defect.id %>">
+          <div class="relative w-full flex justify-start">
+            <%= render partial: 'defect/action_dropdown', locals: { defect: defect } %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/defect/_defect_order_status.html.erb
+++ b/app/views/defect/_defect_order_status.html.erb
@@ -1,15 +1,35 @@
-<% statuses_order = ['TO DO', 'In Progress'] %>
-<% status_groups = @defects.group_by { |d| d.statuses.first&.name } %>
+<%
+  status_to_group = {
+    'TO DO' => 'To Do',
+    'In Progress' => 'In Progress',
+    'On hold' => 'In Progress',
+    'Awaiting build' => 'In Progress',
+    'QA testing' => 'In Progress',
+    'On Hold' => 'On Hold',
+    'Awaiting client info' => 'On Hold'
+  }
 
-<% statuses_order.each do |status| %>
-  <% defects_for_status = status_groups[status]&.uniq { |defect| defect.id } || [] %>
-  <% if defects_for_status.any? %>
+  statuses_order = ['To Do', 'In Progress', 'On Hold']
+
+  grouped_defects = Hash.new { |h, k| h[k] = [] }
+  @defects.each do |defect|
+    status_name = defect.statuses.first&.name
+    group = status_to_group[status_name]
+    # If status isn't mapped, you can skip or put in 'Other'
+    grouped_defects[group] << defect if group
+  end
+%>
+
+<% statuses_order.each do |group| %>
+  <% defects_for_group = grouped_defects[group].uniq { |defect| defect.id } %>
+  <% if defects_for_group.any? %>
     <tr>
       <th colspan="8" class="bg-gray-100 dark:bg-gray-900 text-lg font-bold px-6 py-3 border-b border-t dark:border-gray-700">
-        <%= status %>
+        <%= group %>
       </th>
     </tr>
-    <% defects_for_status.each do |defect| %>
+    <% defects_for_group.each do |defect| %>
+      <!-- Your defect row rendering here, unchanged -->
       <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-left" style="cursor:pointer;" onclick="window.location='<%= defect_path(defect.id) %>'">
         <td class="px-6 py-4">
           <%= defect.defect_unique %>


### PR DESCRIPTION
This pull request refactors the defect listing view to group defects by their status, making it easier to see which defects are in each workflow stage. Instead of rendering all defects in a flat list, defects are now displayed in grouped sections such as "To Do", "In Progress", and "On Hold". The logic for grouping and rendering these sections has been moved to a new partial for better organization and maintainability.

Defect grouping and rendering:

* Added a new partial, `app/views/defect/_defect_order_status.html.erb`, which groups defects by status ("To Do", "In Progress", "On Hold") using a mapping and renders each group with a header and its defects.
* Updated `app/views/defect/_defect.html.erb` to render the new grouped partial instead of iterating through defects directly, removing the previous flat defect row rendering logic.