### PR TITLE
Sentry fix

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -11,7 +11,7 @@ class DefectController < ApplicationController
     @defects = @defects.joins(:users).where(users: { id: current_user.id }) unless current_user.has_any_role?(:admin, :observer)
 
     # Pagination
-    @per_page = 12
+    @per_page = 20
     @page = (params[:page] || 1).to_i
     @total_pages = (@defects.count / @per_page.to_f).ceil
     @start_count = ((@page - 1) * @per_page) + 1

--- a/app/controllers/defect_messages_controller.rb
+++ b/app/controllers/defect_messages_controller.rb
@@ -15,7 +15,7 @@ class DefectMessagesController < ApplicationController
       search_query = "%#{params[:query].strip}%"
       @defect_messages = @defect_messages
         .joins("LEFT JOIN action_text_rich_texts ON action_text_rich_texts.record_id = defect_messages.id AND action_text_rich_texts.record_type = 'DefectMessage'")
-        .where("action_text_rich_texts.body ILIKE :q", q: search_query)
+        .where('action_text_rich_texts.body ILIKE :q', q: search_query)
     end
 
     # Sorting
@@ -27,12 +27,12 @@ class DefectMessagesController < ApplicationController
                        end
 
     # Pagination
-    @per_page     = (params[:per_page] || 10).to_i
-    @page         = (params[:page] || 1).to_i
-    @total_count  = @defect_messages.count
-    @total_pages  = (@total_count / @per_page.to_f).ceil
-    @start_count  = ((@page - 1) * @per_page) + 1
-    @end_count    = [@page * @per_page, @total_count].min
+    @per_page = (params[:per_page] || 10).to_i
+    @page = (params[:page] || 1).to_i
+    @total_count = @defect_messages.count
+    @total_pages = (@total_count / @per_page.to_f).ceil
+    @start_count = ((@page - 1) * @per_page) + 1
+    @end_count = [@page * @per_page, @total_count].min
 
     @defect_messages = @defect_messages.offset((@page - 1) * @per_page).limit(@per_page)
   end
@@ -44,12 +44,14 @@ class DefectMessagesController < ApplicationController
     if @defect_message.save
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to defect_path(@defect), notice: "Message posted!" }
+        format.html { redirect_to defect_path(@defect), notice: 'Message posted!' }
       end
     else
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: turbo_stream.replace("new_defect_message", partial: "defect_messages/form", locals: { defect: @defect, defect_message: @defect_message }) }
-        format.html { render "defect/show", status: :unprocessable_entity }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('new_defect_message', partial: 'defect_messages/form', locals: { defect: @defect, defect_message: @defect_message })
+        end
+        format.html { render 'defect/show', status: :unprocessable_entity }
       end
     end
   end
@@ -60,7 +62,7 @@ class DefectMessagesController < ApplicationController
     if @defect_message.update(defect_message_params)
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to @defect, notice: "Message updated successfully." }
+        format.html { redirect_to @defect, notice: 'Message updated successfully.' }
       end
     else
       render :edit, status: :unprocessable_entity
@@ -71,13 +73,13 @@ class DefectMessagesController < ApplicationController
     if audit_soft_delete(@defect_message)
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to @defect, notice: "Message archived successfully." }
+        format.html { redirect_to @defect, notice: 'Message archived successfully.' }
       end
     else
       @defect_message.destroy
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to @defect, notice: "Message deleted permanently." }
+        format.html { redirect_to @defect, notice: 'Message deleted permanently.' }
       end
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -176,6 +176,12 @@ class HomeController < ApplicationController
       # COunt of all tickets created in the last one week count
       @tickets_created_in_last_one_week_count = Ticket.where('created_at >= ?', 1.week.ago).count
 
+      @all_tickets_created_by_inactive_users = Ticket.joins(:statuses, :project, :users)
+        .where.not(statuses: { name: %w[Closed Resolved Declined Approved] })
+        .where(users: { active: false })
+        .distinct
+        .count
+
       # Get the total number of open tickets for the current user count
       @total_no_of_open_tickets_for_current_user_count = Ticket.joins(:statuses, :project)
         .where(projects: { id: current_user.projects.ids })
@@ -212,6 +218,7 @@ class HomeController < ApplicationController
 
       # Count the total number of service desks\
       @all_service_desks_count = Project.distinct.count
+
     end
   end
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -590,6 +590,28 @@ class TicketsController < ApplicationController
     @tickets = @tickets.offset((@page - 1) * @per_page).limit(@per_page)
   end
 
+  # Show all tickets where user active is not true
+
+  def show_all_tickets_user_inactive
+    @tickets = Ticket.joins(:statuses, :project, :users)
+      .where.not(statuses: { name: %w[Closed Resolved Declined Approved] })
+      .where(users: { active: false })
+      .distinct
+
+    if params[:search].present?
+      search = "%#{params[:search]}%"
+      @tickets = @tickets.where(
+        'projects.title ILIKE :search OR statuses.name ILIKE :search OR users.first_name ILIKE :search OR users.last_name ILIKE :search',
+        search: search
+      )
+    end
+
+    @per_page = 50
+    @page = (params[:page] || 1).to_i
+    @total_pages = (@tickets.count / @per_page.to_f).ceil
+    @tickets = @tickets.offset((@page - 1) * @per_page).limit(@per_page)
+  end
+
   def modal_show
     @ticket_items = if params[:query].present?
                       @ticket.issues.left_joins(:rich_text_content)

--- a/app/views/defect/index.html.erb
+++ b/app/views/defect/index.html.erb
@@ -17,3 +17,4 @@
 <div class="mb-4 h-full">
   <%= render 'defect/defect' %>
 </div>
+

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -114,6 +114,21 @@
           </p>
         </div>
       <% end %>
+      <% if current_user.projects.any? %>
+        <%= link_to show_all_tickets_user_inactive_project_tickets_path(project_id: current_user.projects.first.id) do %>
+          <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+            <p class="text-xs sm:text-sm truncate">
+              All Tickets created by inactive users
+            </p>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+          <p class="text-xs sm:text-sm truncate">
+            No Tickets Created in the last one week
+          </p>
+        </div>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,7 @@
 <div class="p-4 border-2 border-white rounded-lg flex flex-col items-center">
   <!-- Topbar Section  for admin and observer-->
   <% if current_user.has_role?(:admin) or current_user.has_role?(:observer) %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mb-6 w-full ">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2 mb-6 w-full ">
       <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
         <p class="text-xs sm:text-sm truncate">
           All Service Desks
@@ -120,6 +120,9 @@
             <p class="text-xs sm:text-sm truncate">
               All Tickets created by inactive users
             </p>
+            <span class="text-lg sm:text-xl font-bold">
+              <%= @all_tickets_created_by_inactive_users %>
+            </span>
           </div>
         <% end %>
       <% else %>

--- a/app/views/tickets/show_all_tickets_user_inactive.html.erb
+++ b/app/views/tickets/show_all_tickets_user_inactive.html.erb
@@ -76,12 +76,12 @@
 <!-- Pagination Links -->
 <div class="mt-4">
   <% if @page > 1 %>
-    <%= link_to 'Previous', all_tickets_project_tickets_path(@project, page: @page - 1),
+    <%= link_to 'Previous', show_all_tickets_user_inactive_project_tickets_path(@project, page: @page - 1),
                 class: 'bg-blue-600 hover:bg-blue-500 px-4 rounded text-white text-sm font-semibold transition-all p-2 uppercase'
     %>
   <% end %>
   <% if @page < @total_pages %>
-    <%= link_to 'Next', all_tickets_project_tickets_path(@project, page: @page + 1),
+    <%= link_to 'Next', show_all_tickets_user_inactive_project_tickets_path(@project, page: @page + 1),
                 class: 'bg-blue-600 hover:bg-blue-500 px-4 rounded text-white text-sm font-semibold transition-all p-2 uppercase'
     %>
   <% end %>

--- a/app/views/tickets/show_all_tickets_user_inactive.html.erb
+++ b/app/views/tickets/show_all_tickets_user_inactive.html.erb
@@ -1,0 +1,88 @@
+<table class="min-w-full bg-white dark:bg-gray-800">
+  <thead>
+  <tr>
+    <th class="py-2 px-4 border-b">ID</th>
+    <th class="py-2 px-4 border-b">Date</th>
+    <th class="py-2 px-4 border-b">SERVICE DESK NAME</th>
+    <th class="py-2 px-4 border-b">ISSUE</th>
+    <th class="py-2 px-4 border-b">PRIORITY</th>
+    <th class="py-2 px-4 border-b">SUMMARY</th>
+    <th class="py-2 px-4 border-b">ASSIGNEE</th>
+    <th class="py-2 px-4 border-b">STATUS</th>
+    <th class="py-2 px-4 border-b">PROGRESS</th>
+    <th class="py-2 px-4 border-b">VIEW</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @tickets.each do |ticket| %>
+    <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white uppercase">
+        <%= link_to ticket.unique_id, project_ticket_path(ticket.project, ticket) if ticket.unique_id.present? %>
+      </th>
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+        <%= link_to ticket.created_at.strftime("%d %b %Y"), project_ticket_path(ticket.project, ticket) %>
+      </th>
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+        <%= link_to ticket.project.title, project_ticket_path(ticket.project, ticket) %>
+      </th>
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+        <%= link_to ticket.issue, project_ticket_path(ticket.project, ticket) %>
+      </th>
+      <!-- Priority -->
+      <td class="px-2 py-2">
+        <div class="relative w-full flex justify-center">
+          <%= render partial: "tickets/priority_severity", locals: { ticket: ticket } %>
+        </div>
+      </td>
+      <td class="px-4 py-4 grid grid-cols-[auto_1fr_auto] items-center gap-3 sm:gap-4">
+        <%= render partial: 'tickets/summary', locals: { ticket: ticket } %>
+      </td>
+      <td class="px-4 py-4 whitespace-nowrap">
+        <div class="flex flex-col gap-2">
+          <% ticket.users.each do |user| %>
+            <% if user.name.present? %>
+              <span class="font-medium"><%= user.name %></span>
+              <span class="font-semibold">
+                <% if user.teams.any? %>
+                  (<%= user.teams.map(&:name).join(', ') %>)
+                <% else %>
+                  (No Team Assigned)
+                <% end %>
+              </span>
+            <% end %>
+          <% end %>
+        </div>
+      </td>
+      <!-- Ticket Status -->
+      <td class="px-2 py-2">
+        <div class="relative w-full flex justify-center">
+          <%= render partial: "tickets/ticket_status", locals: { ticket: ticket } %>
+        </div>
+      </td>
+      <!-- Progress Bar -->
+      <td class="pl-2 pr-2 py-2">
+        <div class="relative w-full flex justify-center">
+          <%= render partial: "tickets/progress_bar", locals: { ticket: ticket } %>
+        </div>
+      </td>
+      <td class="px-4 py-4 whitespace-nowrap font-medium" data-controller="dropdown" data-dropdown-ticket-id-value="<%= ticket.id %>">
+        <%= render partial: 'tickets/action_dropdown', locals: { ticket: ticket } %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<!-- Pagination Links -->
+<div class="mt-4">
+  <% if @page > 1 %>
+    <%= link_to 'Previous', all_tickets_project_tickets_path(@project, page: @page - 1),
+                class: 'bg-blue-600 hover:bg-blue-500 px-4 rounded text-white text-sm font-semibold transition-all p-2 uppercase'
+    %>
+  <% end %>
+  <% if @page < @total_pages %>
+    <%= link_to 'Next', all_tickets_project_tickets_path(@project, page: @page + 1),
+                class: 'bg-blue-600 hover:bg-blue-500 px-4 rounded text-white text-sm font-semibold transition-all p-2 uppercase'
+    %>
+  <% end %>
+</div>

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 # Only initialize Sentry when a DSN is provided.
-dsn = ENV["SENTRY_DSN"].presence
-if dsn
-  Sentry.init do |config|
-    config.dsn = dsn
-    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+Sentry.init do |config|
+  config.dsn = 'https://2c85eaaa604d06def24a5250f6595b55@o4507601057808384.ingest.de.sentry.io/4509908884783184'
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
-    # Keep tracing minimal by default; override via env if desired
-    config.traces_sample_rate = (ENV["SENTRY_TRACES_SAMPLE_RATE"] || 0.0).to_f
-    config.profiles_sample_rate = (ENV["SENTRY_PROFILES_SAMPLE_RATE"] || 0.0).to_f
-  end
+  # Add data like request headers and IP for users,
+  # see https://docs.sentry.io/platforms/ruby/data-management/data-collected/ for more info
+  config.send_default_pii = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         get 'created_tickets_one_week'
         get 'all_open_tickets'
         get 'non_breached_sla_tickets'
+        get 'show_all_tickets_user_inactive'
       end
       member do
         get :modal_show

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -251,7 +251,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_25_082717) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary", null: false
+    t.string "summary"
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.index ["banking_type_id"], name: "index_defects_on_banking_type_id"


### PR DESCRIPTION
This pull request introduces a new feature to display and manage tickets created by inactive users, along with several UI and configuration improvements. The most notable changes include the addition of a controller action and view for listing tickets by inactive users, updates to the home dashboard to show counts and links for these tickets, and an update to Sentry configuration for error tracking. Minor improvements to pagination and text consistency are also included.

**Feature: Tickets Created by Inactive Users**
* Added `show_all_tickets_user_inactive` action to `TicketsController` to list tickets created by inactive users, with search and pagination support.
* Created new view `show_all_tickets_user_inactive.html.erb` to display these tickets in a paginated table.
* Updated routes to expose the new action under project tickets.

**Dashboard and UI Enhancements**
* Home dashboard (`home_controller.rb` and `index.html.erb`) now displays the count of tickets created by inactive users and provides a link to view them; grid layout updated to accommodate the new metric. [[1]](diffhunk://#diff-2e1b0bda5d1af14b6acbbff496f78d7343528dcd5d1f58aa7259c9b73f2deb5aR179-R184) [[2]](diffhunk://#diff-70acf32a949fd60a5a3d1ae8bbca9090058a7f011f201c41e6a8b1a51ea12c02R117-R134) [[3]](diffhunk://#diff-70acf32a949fd60a5a3d1ae8bbca9090058a7f011f201c41e6a8b1a51ea12c02L6-R6)
* Increased pagination size for defects from 12 to 20 per page for improved usability.

**Configuration and Consistency**
* Sentry error tracking is now always initialized with a hardcoded DSN and sends default PII data for enhanced monitoring.
* Standardized quotation marks in notices and render statements for consistency in `defect_messages_controller.rb`. [[1]](diffhunk://#diff-9e670538fa3b806647c65cc66ba0102ce106cfa6ddc0f5be85b086848f0d86a8L47-R54) [[2]](diffhunk://#diff-9e670538fa3b806647c65cc66ba0102ce106cfa6ddc0f5be85b086848f0d86a8L63-R65) [[3]](diffhunk://#diff-9e670538fa3b806647c65cc66ba0102ce106cfa6ddc0f5be85b086848f0d86a8L74-R82) [[4]](diffhunk://#diff-9e670538fa3b806647c65cc66ba0102ce106cfa6ddc0f5be85b086848f0d86a8L18-R18)

**Other Minor Changes**
* The `summary` field in the `defects` table is no longer required (nullable).
* Minor whitespace and formatting improvements in views. [[1]](diffhunk://#diff-d4f36d67a2e65b5060232a7dba6b11ec0b21183badc76571ba7c3f20ed653240R20) [[2]](diffhunk://#diff-2e1b0bda5d1af14b6acbbff496f78d7343528dcd5d1f58aa7259c9b73f2deb5aR221)