### PR TITLE
Support File Attachments in Defect Messages (Rich Text Editor)

### DIFF
--- a/app/views/defect_messages/_defect_message.html.erb
+++ b/app/views/defect_messages/_defect_message.html.erb
@@ -2,7 +2,8 @@
 <div id="defect-messages" class="mt-8 w-full">
   <h2 class="text-xl font-semibold mb-4">Messages</h2>
 
-  <div class="space-y-4 w-full">
+  <!-- Scrollable Messages Container -->
+  <div class="space-y-4 w-full max-h-[80vh] overflow-y-auto pr-2">
     <% if @defect.defect_messages.any? %>
       <ul class="space-y-4 w-full">
         <% @defect.defect_messages.order(created_at: :asc).each do |message| %>

--- a/app/views/defect_messages/_message.html.erb
+++ b/app/views/defect_messages/_message.html.erb
@@ -33,10 +33,11 @@
           <%= link_to 'Delete',
               defect_defect_message_path(message.defect, message),
               data: { 
-                  turbo_method: :delete,
-                  turbo_confirm: 'Are you sure?',
-                  turbo_frame: "_top"
+                turbo_method: :delete,
+                turbo_confirm: 'Are you sure?',
+                turbo_frame: "_top"
               },
+              onclick: "setTimeout(function(){ window.location.reload(); }, 500)",
               class: "text-xs px-2.5 py-0.5 rounded bg-red-200 text-red-900 hover:bg-red-300 dark:bg-red-700 dark:text-red-100 hover:no-underline" %>
         </div>
       <% end %>
@@ -81,3 +82,12 @@
 </div>
 
 <%= turbo_frame_tag dom_id(message, :edit) %>
+
+
+<script>
+  document.addEventListener("turbo:submit-end", function(e) {
+    if (e.detail.success) {
+      window.location.reload();
+    }
+  });
+</script>

--- a/app/views/defect_messages/_message.html.erb
+++ b/app/views/defect_messages/_message.html.erb
@@ -46,6 +46,37 @@
     <div class="prose dark:prose-invert max-w-none <%= message.user == current_user ? 'text-blue-900 dark:text-blue-100' : 'text-gray-700 dark:text-gray-300' %>">
       <%= message.content.to_s %>
     </div>
+
+    <!-- Attachments Preview -->
+    <% if message.content.embeds.any? %>
+      <div class="mt-4 space-y-4">
+        <% message.content.embeds.each do |file| %>
+          <div class="p-2 border rounded-lg bg-gray-50 dark:bg-gray-700">
+            <% if file.image? %>
+              <%= image_tag file, class: "rounded max-h-64" %>
+            <% elsif file.video? %>
+              <video controls class="rounded max-h-64 w-full">
+                <source src="<%= url_for(file) %>" type="<%= file.content_type %>">
+                Your browser does not support the video tag.
+              </video>
+            <% else %>
+              <%= link_to file.filename.to_s, url_for(file), class: "text-blue-600 dark:text-blue-400 underline", target: "_blank" %>
+            <% end %>
+
+            <!-- Metadata -->
+            <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+              <p><strong>Title:</strong> <%= file.filename.to_s %></p>
+              <p><strong>Size:</strong> <%= number_to_human_size(file.byte_size) %></p>
+              <p><strong>Uploaded at:</strong> <%= file.created_at.strftime("%b %d, %Y %I:%M %p") if file.created_at %></p>
+              <p>
+                <%= link_to "Download", rails_blob_path(file, disposition: "attachment"), 
+                      class: "inline-block mt-1 px-2 py-1 bg-blue-100 text-blue-800 rounded hover:bg-blue-200 dark:bg-blue-800 dark:text-blue-100" %>
+              </p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/defect_messages/_messages.html.erb
+++ b/app/views/defect_messages/_messages.html.erb
@@ -1,3 +1,0 @@
-<% defect_messages.each do |message| %>
-  <%= render "defect_messages/message", message: message %>
-<% end %>

--- a/app/views/defect_messages/edit.html.erb
+++ b/app/views/defect_messages/edit.html.erb
@@ -6,7 +6,9 @@
       </div>
       <div class="flex space-x-2">
         <%= f.submit "Update",
-                     class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700" %>
+          class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700",
+          onclick: "setTimeout(function(){ window.location.reload(); }, 500)" %>
+
         <%= link_to "Cancel",
                     defect_path(@defect),
                     class: "px-4 py-2 bg-gray-300 text-gray-800 rounded-lg hover:bg-gray-400",


### PR DESCRIPTION
Defect messages currently use a rich text editor (Action Text), but users cannot attach files directly within the editor. We need to extend the functionality to allow users to attach files (images, videos, documents, etc.) inside the rich text editor, and display these attachments properly in the comments section.

This will enhance defect collaboration by letting users add screenshots, logs, and other files directly within the context of their message.

On edit of a defect message/ delete of a defect message, refresh the page to update the view of available defect messages.

This PR handles this issue #73 