### PR TITLE
Dynamic filter for defect index

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -4,11 +4,21 @@ class DefectController < ApplicationController
 
   def index
     # Base query for defects
-    @defects = Defect.includes(:users, :qa_module, :submodule, :banking_type)
-      .order(created_at: :desc)
+    @defects = Defect.includes(:users, :qa_module, :submodule, :banking_type, :statuses)
+                    .order(created_at: :desc)
 
     # Filter defects for non-admin users
     @defects = @defects.joins(:users).where(users: { id: current_user.id }) unless current_user.has_any_role?(:admin, :observer, :qa)
+
+    # Status filter
+    if params[:status].present?
+      @defects = @defects.joins(:statuses).where(statuses: { id: params[:status] })
+    end
+
+    # Search filter
+    if params[:query].present?
+      @defects = @defects.where("summary ILIKE ?", "%#{params[:query]}%")
+    end
 
     # Pagination
     @per_page = 20
@@ -18,6 +28,12 @@ class DefectController < ApplicationController
     @end_count = [@page * @per_page, @defects.count].min
     @total_count = @defects.count
     @defects = @defects.offset((@page - 1) * @per_page).limit(@per_page)
+
+    # ✅ Collect distinct statuses for dropdown (only from the currently matching defects)
+    @statuses = Status.joins(:defects)
+                      .where(defects: { id: @defects.pluck(:id) })
+                      .distinct
+                      .order(:name)
   end
 
   def show

--- a/app/javascript/controllers/status_filter_controller.js
+++ b/app/javascript/controllers/status_filter_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit(event) {
+    this.element.requestSubmit()
+  }
+}

--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -30,11 +30,17 @@
   <!-- Pagination Controls -->
   <div class="pagination">
     <% if @page > 1 %>
-      <%= link_to 'Previous', defect_index_path(page: @page - 1, query: params[:query]), class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
+      <%= link_to 'Previous',
+        defect_index_path(page: @page - 1, query: params[:query], status: params[:status]),
+        class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
     <% end %>
+
     <span>Page <%= @page %> of <%= @total_pages %></span>
+
     <% if @page < @total_pages %>
-      <%= link_to 'Next', defect_index_path(page: @page + 1, query: params[:query]), class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
+      <%= link_to 'Next',
+        defect_index_path(page: @page + 1, query: params[:query], status: params[:status]),
+        class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
     <% end %>
   </div>
 </div>

--- a/app/views/defect/_top_bar.html.erb
+++ b/app/views/defect/_top_bar.html.erb
@@ -1,34 +1,37 @@
-<div class="grid grid-cols-2 ">
+<div class="grid grid-cols-2">
   <div class="col-span-1">
-        <div class="flex gap-1">
-          <%= button_to root_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100', id: 'button' do %>
-            &#8656; Back
-          <% end %>
-
-          <%= button_to '+ Create ', new_defect_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded-md font-bold rounded-lg text-slate-100', id: 'button' %>
-          <%= button_to '+ Create Module ', new_qa_module_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded-md font-bold rounded-lg text-slate-100', id: 'button' %>
-          <%= button_to '+ Create Banking Type ', new_banking_type_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded-md font-bold rounded-lg text-slate-100', id: 'button' %>
-        </div>
-  </div>
-  <!-- Search on the right -->
-  <div class="grid col-span-1 justify-end">
-    <div class="flex flex-col md:flex-row items-start md:items-center w-full">
-      <%= form_with url: defect_index_path, method: :get, class: 'flex gap-2' do |f| %>
-        <%= f.text_field :query, placeholder: "Search ", class: "border border-gray-300 px-5 pr-10 rounded-md font-medium placeholder-current focus:outline-none dark:bg-gray-700 dark:border-gray-50 dark:text-slate-100" %>
-        <%= f.submit "Search",  class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100'  %>
+    <div class="flex gap-1">
+      <%= button_to root_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100', id: 'button' do %>
+        &#8656; Back
       <% end %>
+
+      <%= button_to '+ Create ', new_defect_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded-md font-bold rounded-lg text-slate-100', id: 'button' %>
+      <%= button_to '+ Create Module ', new_qa_module_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded-md font-bold rounded-lg text-slate-100', id: 'button' %>
+      <%= button_to '+ Create Banking Type ', new_banking_type_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded-md font-bold rounded-lg text-slate-100', id: 'button' %>
+    </div>
+  </div>
+
+  <!-- Right side: search + filter -->
+  <div class="grid col-span-1 justify-end">
+    <div class="flex flex-col md:flex-row items-start md:items-center w-full gap-2">
+      <!-- Search -->
+      <%= form_with url: defect_index_path, method: :get, class: 'flex gap-2' do |f| %>
+        <%= f.text_field :query, value: params[:query], placeholder: "Search", class: "border border-gray-300 px-5 pr-10 rounded-md font-medium placeholder-current focus:outline-none dark:bg-gray-700 dark:border-gray-50 dark:text-slate-100" %>
+        <%= f.submit "Search", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100' %>
+      <% end %>
+
+      <!-- Clear button -->
       <%= form_with url: defect_index_path, method: :get, class: 'flex' do |f| %>
-        <%= f.submit "Clear", class: 'ml-2 bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100'  %>
+        <%= f.submit "Clear", class: 'ml-2 bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100' %>
+      <% end %>
+
+      <!-- Status Filter Dropdown -->
+      <%= form_with url: defect_index_path, method: :get, class: 'flex', data: { controller: "status-filter" } do |f| %>
+        <%= f.select :status, options_from_collection_for_select(@statuses, :id, :name, params[:status]),
+          { include_blank: "All Statuses" },
+          class: "ml-2 border border-gray-300 rounded-md px-3 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-50 dark:text-slate-100",
+          data: { action: "change->status-filter#submit" } %>
       <% end %>
     </div>
   </div>
 </div>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const button = document.getElementById('button');
-    button.addEventListener('click', function() {
-      button.style.backgroundColor = '#1F6DE0';
-    });
-  });
-</script>


### PR DESCRIPTION
On the Defects Index page, we want to add a status filter dropdown that dynamically lists only the statuses currently present among the displayed defects. When a user selects a status, the page should filter and display only defects that match that status.

This will help users quickly narrow down defects without cluttering the filter with unused statuses.