### PR TITLE
Permission fixed fix

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -5,20 +5,16 @@ class DefectController < ApplicationController
   def index
     # Base query for defects
     @defects = Defect.includes(:users, :qa_module, :submodule, :banking_type, :statuses)
-                    .order(created_at: :desc)
+      .order(created_at: :desc)
 
     # Filter defects for non-admin users
     @defects = @defects.joins(:users).where(users: { id: current_user.id }) unless current_user.has_any_role?(:admin, :observer, :qa)
 
     # Status filter
-    if params[:status].present?
-      @defects = @defects.joins(:statuses).where(statuses: { id: params[:status] })
-    end
+    @defects = @defects.joins(:statuses).where(statuses: { id: params[:status] }) if params[:status].present?
 
     # Search filter
-    if params[:query].present?
-      @defects = @defects.where("summary ILIKE ?", "%#{params[:query]}%")
-    end
+    @defects = @defects.where('summary ILIKE ?', "%#{params[:query]}%") if params[:query].present?
 
     # Pagination
     @per_page = 20
@@ -31,9 +27,9 @@ class DefectController < ApplicationController
 
     # ✅ Collect distinct statuses for dropdown (only from the currently matching defects)
     @statuses = Status.joins(:defects)
-                      .where(defects: { id: @defects.pluck(:id) })
-                      .distinct
-                      .order(:name)
+      .where(defects: { id: @defects.pluck(:id) })
+      .distinct
+      .order(:name)
   end
 
   def show

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,14 +15,26 @@ class Ability
       can :manage, Issue, user_id: user.id
 
     elsif user.has_role? :hod
-      can %i[show_all_tickets_user_inactive all_tickets_created_by_inactive_team_members], Ticket
+      can %i[read assign_user unassign_user add_team manage_users], Project
+      can %i[create read assign_tag unassign_tag add_status update_issue_type update_due_date update_priority index_home all_tickets modal_show show_all_tickets_user_inactive all_tickets_created_by_inactive_team_members],
+          Ticket
+      can %i[edit destroy update], Ticket, user_id: user.id
+      can :manage, Issue, user_id: user.id
+      can %i[create read add_user remove_user edit update manage_users product_status], Product
+      cannot %i[delete], Product
+      can %i[create edit read], User, roles: { name: ['agent', 'client', 'project manager'] }
+      cannot :manage, User, roles: { name: 'admin' }
+      can :manage, Board
+      can :manage, Task
+      can :generate, :report
+      can :manage, Team
 
     elsif user.has_role? :ceo
       can :generate, :report # allow ceo to do anything cept manage all
 
     elsif user.has_role?('project manager')
       can %i[read assign_user unassign_user add_team manage_users], Project
-      can %i[create read assign_tag unassign_tag add_status update_issue_type update_due_date update_priority index_home all_tickets modal_show all_tickets_created_by_inactive_team_members all_tickets_created_by_inactive_users],
+      can %i[create read assign_tag unassign_tag add_status update_issue_type update_due_date update_priority index_home all_tickets modal_show show_all_tickets_user_inactive all_tickets_created_by_inactive_team_members],
           Ticket
       can %i[edit destroy update], Ticket, user_id: user.id
       can :manage, Issue, user_id: user.id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,7 +34,7 @@ class Ability
 
     elsif user.has_role?('project manager')
       can %i[read assign_user unassign_user add_team manage_users], Project
-      can %i[create read assign_tag unassign_tag add_status update_issue_type update_due_date update_priority index_home all_tickets modal_show show_all_tickets_user_inactive all_tickets_created_by_inactive_team_members],
+      can %i[create read assign_tag unassign_tag add_status update_issue_type update_due_date update_priority index_home all_tickets modal_show],
           Ticket
       can %i[edit destroy update], Ticket, user_id: user.id
       can :manage, Issue, user_id: user.id


### PR DESCRIPTION
This pull request primarily expands and refines role-based permissions for the `hod` (Head of Department) and `project manager` roles in the `Ability` model, while also simplifying conditional logic in the `DefectController`. The changes improve maintainability and clarity, and ensure that users with specific roles have the correct access to features.

**Role-based permissions updates:**

* Expanded permissions for the `hod` role to include managing `Project`, `Product`, `Board`, `Task`, `Team`, and generating reports, while restricting certain actions like deleting products and managing admin users.
* Refined permissions for the `project manager` role, removing access to tickets created by inactive users and clarifying ticket-related actions.

**Codebase simplification:**

* Streamlined conditional logic in `DefectController#index` by converting multi-line `if` statements for status and search filters into single-line expressions, improving readability.