### PR TITLE
Ability change to ensure users are able to get the details

### DIFF
--- a/app/views/defect/_defect_order_status.html.erb
+++ b/app/views/defect/_defect_order_status.html.erb
@@ -34,7 +34,11 @@
       </div>
     </td>
     <td class="px-6 py-4">
-      <%= "#{defect.product.client.name} #{defect.product.groupwares.first&.name}".truncate(30) %>
+      <%= link_to(
+            "#{defect.product.client.name} #{defect.product.groupwares.first&.name}".truncate(30),
+            product_path(defect.product),
+            class: "text-blue-600 hover:underline"
+          ) %>
     </td>
     <td class="px-6 py-4 text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= defect.id %>">
       <div class="relative w-full flex justify-start">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -262,7 +262,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary", null: false
+    t.string "summary"
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.string "label"


### PR DESCRIPTION
This pull request introduces a couple of targeted improvements to the defect order status view and updates the database schema. The most notable change is making the product and client name clickable, linking to the product's detail page, which enhances navigation for users. Additionally, the `summary` field in the defects table is now nullable, allowing for more flexibility in defect records.

**User interface enhancement:**

* Made the product and client name in the defect order status table a clickable link to the product detail page, improving navigation and user experience (`app/views/defect/_defect_order_status.html.erb`).

**Database schema update:**

* Changed the `summary` column in the `defects` table to allow null values, increasing flexibility for defect entries (`db/schema.rb`).