### PR TITLE
Product module connection

### DIFF
--- a/app/controllers/qa_modules_controller.rb
+++ b/app/controllers/qa_modules_controller.rb
@@ -1,6 +1,7 @@
 class QaModulesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_qa_module, only: %i[edit update destroy]
+  before_action :set_products_and_clients_defects, only: %i[new create edit update]
 
   def index
     @qa_modules = QaModule.all
@@ -17,7 +18,7 @@ class QaModulesController < ApplicationController
   end
 
   def create
-    @qa_module = QaModule.new(name: params[:qa_module][:name])
+    @qa_module = QaModule.new(name: params[:qa_module][:name], product_id: params[:qa_module][:product_id])
     audit_on_create(@qa_module)
     activity('user_activity')
       .caused_by(current_user)
@@ -47,11 +48,9 @@ class QaModulesController < ApplicationController
 
   def update
     audit_on_update(@qa_module)
-    # Get the parent_id from params if present
     parent_id = params[:qa_module][:parent_id].presence
 
-    # Update attributes
-    if @qa_module.update(name: params[:qa_module][:name], parent_id: parent_id)
+    if @qa_module.update(name: params[:qa_module][:name], parent_id: parent_id, product_id: params[:qa_module][:product_id])
       activity('user_activity')
         .caused_by(current_user)
         .performed_on(@qa_module)
@@ -60,7 +59,7 @@ class QaModulesController < ApplicationController
         .log('QA Module updated')
       redirect_to qa_modules_path, notice: 'Module was successfully updated.'
     else
-      @parents = QaModule.where.not(id: @qa_module.id) # Reload parents for the form
+      @parents = QaModule.where.not(id: @qa_module.id)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -79,7 +78,6 @@ class QaModulesController < ApplicationController
       .log('QA Module removed')
   end
 
-  # filepath: app/controllers/qa_modules_controller.rb
   def submodules
     @submodules = QaModule.where(parent_id: params[:id])
     render json: @submodules.select(:id, :name)
@@ -87,11 +85,22 @@ class QaModulesController < ApplicationController
 
   private
 
+  def set_products_and_clients_defects
+    @products_and_clients_defects = Product.includes(:client, :groupwares, :statuses)
+      .select do |product|
+        product.statuses.any? { |status| ['Pre Quality Assurance', 'End Of Quality Assurance'].include?(status.name) }
+      end.map do |product|
+        client_name = product.client&.name || 'No Client'
+        groupware_names = product.groupwares.any? ? product.groupwares.map(&:name).join(', ') : 'No Software'
+        ["#{client_name} - #{groupware_names}", product.id]
+      end
+  end
+
   def set_qa_module
     @qa_module = QaModule.find(params[:id])
   end
 
   def qa_module_params
-    params.require(:qa_module).permit(:name)
+    params.require(:qa_module).permit(:name, :product_id, :parent_id)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,6 +21,7 @@ class Project < ApplicationRecord
   # Assingnee
   has_many :assignees
   has_many :users, through: :assignees, dependent: :destroy
+  has_many :qa_modules, dependent: :destroy
 
   validates :title, presence: true, uniqueness: true
 

--- a/app/models/qa_module.rb
+++ b/app/models/qa_module.rb
@@ -1,4 +1,5 @@
 class QaModule < ApplicationRecord
+  belongs_to :product
   belongs_to :parent, class_name: 'QaModule', optional: true
   has_many :submodules, class_name: 'QaModule', foreign_key: 'parent_id', dependent: :destroy
 

--- a/app/views/banking_types/new.html.erb
+++ b/app/views/banking_types/new.html.erb
@@ -2,7 +2,7 @@
   <div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
     <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-2xl relative">
       <!-- Close Button -->
-      <%= link_to "X", banking_types_path, data: { action: "modal#close" },
+      <%= link_to "X", banking_types_path, data: { turbo_frame: "_top", action: "modal#close" },
             class: "absolute top-3 right-3 text-xl font-bold text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100" %>
 
       <%= render 'form', banking_type: @banking_type %>

--- a/app/views/qa_modules/_form.html.erb
+++ b/app/views/qa_modules/_form.html.erb
@@ -10,6 +10,13 @@
     </div>
   <% end %>
 
+ <div>
+      <%= f.select :product_id, 
+            options_for_select(@products_and_clients_defects), 
+            { prompt: "Select Project" },
+            { class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", required: true } %>
+    </div>
+
   <div class="mb-4">
     <%= f.label :name, "Module Name", class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" %>
     <%= f.text_field :name, class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white" %>

--- a/app/views/qa_modules/new.html.erb
+++ b/app/views/qa_modules/new.html.erb
@@ -2,7 +2,7 @@
   <div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
     <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-2xl relative">
       <!-- Close Button -->
-      <%= link_to "X", qa_modules_path, data: { action: "modal#close" },
+      <%= link_to "X", qa_modules_path, data: { action: "modal#close" }, data: { turbo_frame: "_top" },
             class: "absolute top-3 right-3 text-xl font-bold text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100" %>
 
       <%= render "form" %>

--- a/db/migrate/20250829115235_add_product_to_qa_modules.rb
+++ b/db/migrate/20250829115235_add_product_to_qa_modules.rb
@@ -1,0 +1,12 @@
+class AddProductToQaModules < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :qa_modules, :product, null: true, foreign_key: true, type: :uuid
+
+    # If you want to backfill with a default product, uncomment and adjust:
+    # default_product_id = Product.first&.id
+    # QaModule.update_all(product_id: default_product_id)
+
+    # Then, set NOT NULL constraint
+    # change_column_null :qa_modules, :product_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_29_115235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -28,6 +28,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
     t.datetime "deleted_on"
     t.index ["deleted_on"], name: "index_action_text_rich_texts_on_deleted_on"
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "action_text_tables", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "content", default: [["", ""], ["", ""]], null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "action_text_tables_table", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "content", default: [["", ""], ["", ""]], null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -226,6 +238,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
     t.uuid "deleted_by_id"
     t.datetime "deleted_on"
     t.boolean "archive_status", default: false, null: false
+    t.text "content"
     t.index ["archive_status"], name: "index_defect_messages_on_archive_status"
     t.index ["created_by_id"], name: "index_defect_messages_on_created_by_id"
     t.index ["defect_id"], name: "index_defect_messages_on_defect_id"
@@ -511,6 +524,21 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 
+  create_table "products_qa_modules", id: false, force: :cascade do |t|
+    t.uuid "product_id", null: false
+    t.uuid "qa_module_id", null: false
+    t.uuid "created_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da"
+    t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da"
+    t.uuid "deleted_by"
+    t.datetime "deleted_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_on"], name: "index_products_qa_modules_on_deleted_on"
+    t.index ["product_id", "qa_module_id"], name: "index_products_qa_modules_on_product_id_and_qa_module_id", unique: true
+    t.index ["product_id"], name: "index_products_qa_modules_on_product_id"
+    t.index ["qa_module_id"], name: "index_products_qa_modules_on_qa_module_id"
+  end
+
   create_table "products_scripts", id: false, force: :cascade do |t|
     t.uuid "product_id", null: false
     t.uuid "script_id", null: false
@@ -587,7 +615,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
     t.uuid "parent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "product_id"
     t.index ["parent_id"], name: "index_qa_modules_on_parent_id"
+    t.index ["product_id"], name: "index_qa_modules_on_product_id"
   end
 
   create_table "ratings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -979,6 +1009,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_085429) do
   add_foreign_key "projects", "groupwares"
   add_foreign_key "projects", "softwares"
   add_foreign_key "projects", "users"
+  add_foreign_key "qa_modules", "products"
   add_foreign_key "ratings", "tickets"
   add_foreign_key "ratings", "users"
   add_foreign_key "scripts", "groupwares"


### PR DESCRIPTION
This pull request introduces support for associating each QA module with a product, improving data relationships and enabling more contextual selection and filtering in the UI. The changes include backend model updates, controller logic enhancements, database migrations, and user interface improvements to ensure QA modules are linked to products and that users can select the relevant product when creating or editing a QA module.

**Backend and Database Changes**

* Added a `belongs_to :product` association to the `QaModule` model, and updated the `Project` model to reference associated QA modules. [[1]](diffhunk://#diff-b4c02c091e28bf6350d362d39a9b668caae4ecdec1260ff573b4dd91954cd36aR2) [[2]](diffhunk://#diff-611e7045e8b0212d101cd856c335296959519af63b80129f51c246a7bbfe7b91R24)
* Added a migration to introduce a nullable `product_id` foreign key to the `qa_modules` table, updated schema accordingly, and ensured referential integrity. [[1]](diffhunk://#diff-1903e6f0984d3b34f7d7af3e9b7d66724059fc51ba0be623c0a398d4395a2ba0R1-R12) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R618-R620) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R1012)

**Controller Logic Improvements**

* Updated `QaModulesController` to permit and handle `product_id` in create and update actions, and added a `set_products_and_clients_defects` method to prepare product selection data for forms. [[1]](diffhunk://#diff-840ffaf13d05197a07965bdb4eb35ea65e1f571a2b4082ecd50ce4157bff29deR4) [[2]](diffhunk://#diff-840ffaf13d05197a07965bdb4eb35ea65e1f571a2b4082ecd50ce4157bff29deL20-R21) [[3]](diffhunk://#diff-840ffaf13d05197a07965bdb4eb35ea65e1f571a2b4082ecd50ce4157bff29deL50-R53) [[4]](diffhunk://#diff-840ffaf13d05197a07965bdb4eb35ea65e1f571a2b4082ecd50ce4157bff29deL82-R104)

**User Interface Enhancements**

* Modified the QA module form to include a product selection dropdown, showing client and groupware context for each product.
* Improved modal close buttons in new QA module and banking type views to work correctly with Turbo Frames. [[1]](diffhunk://#diff-6d820d2c77697995c0e58e2eb070a481ef95c31f8238f8e4394f86d50a97f1a8L5-R5) [[2]](diffhunk://#diff-0a693ea245d52ba401294904eac0bf4970e93b03ea7179de7efef5764787611cL5-R5)