### PR TITLE
Form size screen

### DIFF
--- a/app/views/defect/edit.html.erb
+++ b/app/views/defect/edit.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "modal" do %>
   <div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-start z-50 overflow-y-auto py-8">
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl relative m-4">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90%] relative m-4">
       <!-- Header -->
       <div class="bg-gray-50 dark:bg-gray-700 px-6 py-4 rounded-t-lg border-b border-gray-200 dark:border-gray-600">
         <h2 class="text-xl font-semibold text-gray-800 dark:text-white">Edit Defect</h2>

--- a/app/views/defect/new.html.erb
+++ b/app/views/defect/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= turbo_frame_tag "modal", data: { controller: "modal" } do %>
   <div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 overflow-y-scroll">
-    <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-2xl relative">
+    <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-[90%] h-[90%] relative">
       <!-- Close Button -->
       <%= link_to "✕", defect_index_path,
         data: { turbo_frame: "_top" },


### PR DESCRIPTION
This pull request updates the modal dialogs for creating and editing defects to improve their layout and responsiveness. The most important changes involve adjusting the width and height of the modal containers to better fit the viewport.

**UI/UX Improvements:**

* In `app/views/defect/edit.html.erb`, the modal width is now set to `w-[90%]` instead of `w-full max-w-4xl`, allowing the edit defect modal to use 90% of the viewport width for a more consistent and responsive appearance.
* In `app/views/defect/new.html.erb`, the modal dimensions are changed to `w-[90%] h-[90%]`, making the new defect modal occupy 90% of both the width and height of the viewport, which enhances usability on various screen sizes.