### PR TITLE
Filter QA Modules by Selected Project When Creating a Defect

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -102,6 +102,18 @@ class DefectController < ApplicationController
     end
   end
 
+  def modules_by_product
+    product_id = params[:product_id]
+    
+    if product_id.present?
+      @modules = QaModule.where(product_id: product_id, parent_id: nil).order(:name)
+    else
+      @modules = []
+    end
+
+    render json: @modules.select(:id, :name)
+  end
+
   def edit
     @defect = Defect.find(params[:id])
 

--- a/app/javascript/controllers/project_modules_controller.js
+++ b/app/javascript/controllers/project_modules_controller.js
@@ -1,0 +1,73 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["projectSelect", "moduleSelect", "submoduleSelect"]
+  static values = { 
+    modulesUrl: String,
+    noModulesMessage: { type: String, default: "No modules available" },
+    selectPrompt: { type: String, default: "Select Module" }
+  }
+
+  connect() {
+    this.initializeSelects()
+  }
+
+  initializeSelects() {
+    const projectId = this.projectSelectTarget.value
+    this.toggleModuleSelect(projectId)
+  }
+
+  loadModules() {
+    const projectId = this.projectSelectTarget.value
+    
+    this.toggleModuleSelect(projectId)
+    
+    if (projectId) {
+      this.fetchModules(projectId)
+    }
+  }
+
+  toggleModuleSelect(projectId) {
+    if (projectId) {
+      this.moduleSelectTarget.disabled = false
+      this.moduleSelectTarget.innerHTML = '<option value="">Loading modules...</option>'
+    } else {
+      this.moduleSelectTarget.disabled = true
+      this.moduleSelectTarget.innerHTML = `<option value="">${this.selectPromptValue}</option>`
+      this.clearSubmodules()
+    }
+  }
+
+  async fetchModules(projectId) {
+    try {
+      const response = await fetch(`${this.modulesUrlValue}?product_id=${projectId}`)
+      const modules = await response.json()
+      
+      this.updateModuleSelect(modules)
+    } catch (error) {
+      console.error('Error fetching modules:', error)
+      this.moduleSelectTarget.innerHTML = `<option value="">Error loading modules</option>`
+    }
+  }
+
+  updateModuleSelect(modules) {
+    let options = `<option value="">${this.selectPromptValue}</option>`
+    
+    if (modules.length === 0) {
+      options = `<option value="">${this.noModulesMessageValue}</option>`
+    } else {
+      modules.forEach(module => {
+        options += `<option value="${module.id}">${module.name}</option>`
+      })
+    }
+    
+    this.moduleSelectTarget.innerHTML = options
+    this.clearSubmodules()
+  }
+
+  clearSubmodules() {
+    if (this.hasSubmoduleSelectTarget) {
+      this.submoduleSelectTarget.innerHTML = '<option value="">Select Sub-Module</option>'
+    }
+  }
+}

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -39,8 +39,18 @@ class Defect < ApplicationRecord
   validates :issue_type, presence: true
   validates :product_id, presence: true
   validates :creator_id, presence: true
+  # Add validation to ensure module belongs to selected project
+  validate :qa_module_belongs_to_product
 
   private
+
+  def qa_module_belongs_to_product
+    return if product_id.blank? || qa_module_id.blank?
+    
+    unless QaModule.where(id: qa_module_id, product_id: product_id).exists?
+      errors.add(:qa_module_id, "must belong to the selected project")
+    end
+  end
 
   def set_default_status
     default_status = Status.find_by(name: 'TO DO')

--- a/app/views/defect/_form.html.erb
+++ b/app/views/defect/_form.html.erb
@@ -1,3 +1,4 @@
+<!-- app/views/defect/new.html.erb -->
 <% if @defect.errors.any? %>
   <div id="error_explanation" class="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
     <h2 class="font-semibold mb-2"><%= pluralize(@defect.errors.count, "error") %> prohibited this defect from being saved:</h2>
@@ -10,16 +11,22 @@
 <% end %>
 
 <%= form_with model: @defect, url: defect_index_url, method: :post, data: { turbo: false }, local: true do |f| %>
-  <div class="space-y-4">
+  <div class="space-y-4"
+       data-controller="project-modules"
+       data-project-modules-modules-url-value="<%= modules_by_product_defect_index_path %>">
     
     <!-- Project -->
     <div>
       <%= f.select :product_id, 
             options_for_select(@products_and_clients_defects), 
             { prompt: "Select Project" },
-            { class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", required: true } %>
+            { class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", 
+              required: true,
+              data: { 
+                action: "change->project-modules#loadModules",
+                "project-modules-target": "projectSelect"
+              } } %>
     </div>
-
 
     <!-- Banking type / Module / Submodule -->
     <div class="flex gap-2">
@@ -33,18 +40,24 @@
 
       <!-- Module -->
       <%= f.collection_select :qa_module_id, 
-            @qa_modules || [], :id, :name,
+            [], # Empty array initially, will be populated dynamically
+            :id, :name,
             { prompt: "Select Module" },
-            { class: "flex-1 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", required: true ,
-              id: "qa-module-select",
-              data: { action: "change->modules#loadSubmodules" } } %>
+            { class: "flex-1 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", 
+              required: true,
+              disabled: true,
+              data: { 
+                "project-modules-target": "moduleSelect",
+                action: "change->project-modules#loadSubmodules" 
+              } } %>
 
       <!-- Submodule -->
       <%= f.collection_select :qa_submodule_id, 
-            @submodules || [], :id, :name,
+            [], # Will be populated when module is selected
+            :id, :name,
             { prompt: "Select Sub-Module" },
             { class: "flex-1 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600",
-              id: "submodule-select" } %>
+              data: { "project-modules-target": "submoduleSelect" } } %>
     </div>
 
     <!-- Ticket Title -->
@@ -104,12 +117,10 @@
         <%= f.text_field :issue_type, value: 'Bug', disabled: true,
               class: "border border-gray-300 rounded-md focus:ring-primary-600 focus:border-primary-600 block w-full p-2 bg-gray-100 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white" %>
       </div>
-
     </div>
 
     <!-- Footer -->
     <div class="flex items-center justify-between pt-4 border-t">
-      
       <%= f.submit "Create",
        data: { disable_with: "Creating..." },
             class: "bg-[#3F8CFF] hover:bg-[#3A81EB] text-white font-medium rounded-lg px-6 py-2 shadow-md" %>
@@ -119,24 +130,26 @@
 
 <script>
   document.addEventListener('turbo:load', function () {
-    const moduleSelect = document.getElementById('qa-module-select');
-    const submoduleSelect = document.getElementById('submodule-select');
+    const moduleSelect = document.querySelector('[data-project-modules-target="moduleSelect"]');
+    const submoduleSelect = document.querySelector('[data-project-modules-target="submoduleSelect"]');
 
     if (moduleSelect) {
       moduleSelect.addEventListener('change', function () {
         const moduleId = this.value;
-        submoduleSelect.innerHTML = '<option value="">Select Sub-Module</option>';
-        if (moduleId) {
-          fetch(`/qa_modules/${moduleId}/submodules`)
-            .then(response => response.json())
-            .then(submodules => {
-              submodules.forEach(submodule => {
-                const option = document.createElement('option');
-                option.value = submodule.id;
-                option.textContent = submodule.name;
-                submoduleSelect.appendChild(option);
+        if (submoduleSelect) {
+          submoduleSelect.innerHTML = '<option value="">Select Sub-Module</option>';
+          if (moduleId) {
+            fetch(`/qa_modules/${moduleId}/submodules`)
+              .then(response => response.json())
+              .then(submodules => {
+                submodules.forEach(submodule => {
+                  const option = document.createElement('option');
+                  option.value = submodule.id;
+                  option.textContent = submodule.name;
+                  submoduleSelect.appendChild(option);
+                });
               });
-            });
+          }
         }
       });
     }

--- a/app/views/defect/edit.html.erb
+++ b/app/views/defect/edit.html.erb
@@ -23,15 +23,24 @@
         <% end %>
 
         <%= form_with model: @defect, url: defect_path(@defect), method: :patch, local: true, html: { multipart: true }, data: { turbo: false } do |f| %>
-          <div class="space-y-4">
+          <div class="space-y-4"
+               data-controller="project-modules"
+               data-project-modules-modules-url-value="<%= modules_by_product_defect_index_path %>"
+               data-project-modules-no-modules-message-value="No modules available"
+               data-project-modules-select-prompt-value="Select Module">
             
             <!-- Project -->
             <div>
               <%= f.label :product_id, 'Project (Product) *', class: "block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300" %>
               <%= f.select :product_id,
-                           options_for_select(@products_and_clients_defects),
+                           options_for_select(@products_and_clients_defects, @defect.product_id),
                            { prompt: "Select Project" },
-                           { class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", required: true } %>
+                           { class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600", 
+                             required: true,
+                             data: { 
+                               action: "change->project-modules#loadModules",
+                               "project-modules-target": "projectSelect"
+                             } } %>
             </div>
 
             <!-- Banking type / Module / Submodule -->
@@ -47,19 +56,21 @@
 
               <!-- Module -->
               <%= f.collection_select :qa_module_id, 
-                    @qa_modules || [], :id, :name,
+                    @qa_modules.where(product_id: @defect.product_id) || [], :id, :name,
                     { selected: @defect.qa_module_id, prompt: "Select Module" },
                     { class: "flex-1 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600",
                       required: true,
-                      id: "qa-module-select",
-                      data: { action: "change->modules#loadSubmodules" } } %>
+                      data: { 
+                        "project-modules-target": "moduleSelect",
+                        action: "change->project-modules#loadSubmodules" 
+                      } } %>
 
               <!-- Submodule -->
               <%= f.collection_select :submodule_id, 
                     @submodules || [], :id, :name,
                     { selected: @defect.submodule_id, prompt: "Select Sub-Module" },
                     { class: "flex-1 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600",
-                      id: "submodule-select" } %>
+                      data: { "project-modules-target": "submoduleSelect" } } %>
             </div>
 
             <!-- Ticket Title -->
@@ -141,7 +152,7 @@
                       <% else %>
                         <div class="w-full h-32 bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-2">
                           <svg class="w-12 h-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 极 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 极 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 极 0 00-.293-.707l-5.414-5.414A1 1 极 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
                           </svg>
                         </div>
                       <% end %>
@@ -189,8 +200,9 @@
 <!-- Dynamic Submodule Dropdown -->
 <script>
   document.addEventListener('turbo:load', function () {
-    const moduleSelect = document.getElementById('qa-module-select');
-    const submoduleSelect = document.getElementById('submodule-select');
+    const projectSelect = document.querySelector('[data-project-modules-target="projectSelect"]');
+    const moduleSelect = document.querySelector('[data-project-modules-target="moduleSelect"]');
+    const submoduleSelect = document.querySelector('[data-project-modules-target="submoduleSelect"]');
 
     // Load submodules for the initially selected module
     function loadSubmodulesForSelectedModule() {
@@ -233,6 +245,13 @@
             });
         }
       });
+    }
+
+    // Initialize modules based on selected project when page loads
+    if (projectSelect && projectSelect.value) {
+      // Trigger the loadModules event to populate modules for the selected project
+      const event = new Event('change');
+      projectSelect.dispatchEvent(event);
     }
   });
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :update, :destroy]
     resources :attachments, only: [:create, :destroy]
     collection do
+      get 'modules_by_product'
       get 'get_submodules'  # For loading submodules dynamically
     end
     member do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,18 +30,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_115235) do
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
-  create_table "action_text_tables", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "content", default: [["", ""], ["", ""]], null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "action_text_tables_table", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "content", default: [["", ""], ["", ""]], null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -238,7 +226,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_115235) do
     t.uuid "deleted_by_id"
     t.datetime "deleted_on"
     t.boolean "archive_status", default: false, null: false
-    t.text "content"
     t.index ["archive_status"], name: "index_defect_messages_on_archive_status"
     t.index ["created_by_id"], name: "index_defect_messages_on_created_by_id"
     t.index ["defect_id"], name: "index_defect_messages_on_defect_id"
@@ -275,7 +262,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_115235) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary"
+    t.string "summary", null: false
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.string "label"
@@ -522,21 +509,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_29_115235) do
     t.index ["script_id"], name: "index_products_on_script_id"
     t.index ["software_id"], name: "index_products_on_software_id"
     t.index ["user_id"], name: "index_products_on_user_id"
-  end
-
-  create_table "products_qa_modules", id: false, force: :cascade do |t|
-    t.uuid "product_id", null: false
-    t.uuid "qa_module_id", null: false
-    t.uuid "created_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da"
-    t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da"
-    t.uuid "deleted_by"
-    t.datetime "deleted_on"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["deleted_on"], name: "index_products_qa_modules_on_deleted_on"
-    t.index ["product_id", "qa_module_id"], name: "index_products_qa_modules_on_product_id_and_qa_module_id", unique: true
-    t.index ["product_id"], name: "index_products_qa_modules_on_product_id"
-    t.index ["qa_module_id"], name: "index_products_qa_modules_on_qa_module_id"
   end
 
   create_table "products_scripts", id: false, force: :cascade do |t|


### PR DESCRIPTION
When creating a new Defect, the user should first select a Project. Once a project is chosen, only the QA Modules that belong to that project should be available in the dropdown. This ensures that defects are always tied to the correct module within the chosen project.

Currently, all QA Modules are listed, which is confusing and error-prone. By scoping modules to the selected project, we improve data integrity and user experience.