### PR TITLE
Reorder defect messages UI

### DIFF
--- a/app/views/defect_messages/_content_defect_message.html.erb
+++ b/app/views/defect_messages/_content_defect_message.html.erb
@@ -1,0 +1,177 @@
+<% if message.content.present? %>
+  <span class="break-words overflow-hidden">
+    <%= sanitize(
+          raw(
+            message.content.to_trix_html.gsub(/\[.*?\]/, '').strip
+          ),
+          tags: %w[strong em b i u p br span div h1 h2 h3 h4 h5 h6 blockquote ul ol li a table tr td th thead tbody],
+          attributes: %w[href style border]
+        )
+    %>
+
+    <% if message.content.body.attachments.any? %>
+      <% message.content.body.attachments.each_with_index do |attachment, idx| %>
+        <% if attachment.attachable.is_a?(ActiveStorage::Blob) && attachment.attachable.image? %>
+          <div class="mb-2 image-preview-block">
+            <a href="#"
+               class="image-preview-link"
+               data-image-url="<%= rails_blob_url(attachment.attachable) %>"
+               data-image-download-url="<%= rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true) %>"
+               data-image-name="<%= attachment.attachable.filename.to_s %>"
+               data-image-size="<%= number_to_human_size(attachment.attachable.byte_size) %>"
+               data-image-created-at="<%= attachment.attachable.created_at.strftime('%Y-%m-%d %H:%M') %>"
+               data-image-index="<%= idx %>">
+              <img src="<%= rails_representation_url(attachment.attachable.variant(resize_to_limit: [72,72])) %>"
+                   alt="Image Preview"
+                   class="max-w-xs cursor-pointer pl-2 image-preview-thumb">
+            </a>
+            <br>
+            <%= link_to attachment.attachable.filename.to_s, rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true), target: "_blank", download: true, class: "text-blue-600 hover:underline pl-2" %>
+          </div>
+        <% elsif attachment.attachable.is_a?(ActiveStorage::Blob) %>
+          <!-- Non-image attachments -->
+          <%= link_to attachment.attachable.filename.to_s, rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true), class: "text-blue-600 hover:underline pl-2" %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </span>
+
+  <!-- Modal for image magnification -->
+  <div id="imageModal" class="hidden fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center">
+    <div class="bg-white rounded-lg shadow-lg flex flex-row overflow-hidden max-w-3xl w-full">
+      <div class="flex-1 flex items-center justify-center p-4 bg-gray-900">
+        <img id="modalImage" src="" alt="Magnified Image" class="max-h-[75vh] max-w-[50vw] rounded shadow-lg">
+      </div>
+      <div class="w-64 p-4 bg-gray-100 border-l">
+        <h3 class="font-bold text-lg mb-2">Image Info</h3>
+        <p><strong>Name:</strong> <span id="modalImageName"></span></p>
+        <p><strong>Size:</strong> <span id="modalImageSize"></span></p>
+        <p><strong>Created:</strong> <span id="modalImageCreated"></span></p>
+        <p><strong>Updated:</strong> <span id="modalImageUpdated"></span></p>
+        <div class="mt-3 flex gap-2">
+          <a id="downloadImage" href="#" download class="px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700">Download</a>
+          <button id="closeModal" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<script>
+  // Will reload modal markup to ensure listeners are always fresh after closing
+  function reloadImageModal() {
+    var modal = document.getElementById('imageModal');
+    if (!modal) return;
+    // Remove modal from DOM
+    modal.parentNode.removeChild(modal);
+    // Insert fresh modal markup (same as erb above)
+    var modalHtml = `
+      <div id="imageModal" class="hidden fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center">
+        <div class="bg-white rounded-lg shadow-lg flex flex-row overflow-hidden max-w-3xl w-full">
+          <div class="flex-1 flex items-center justify-center p-4 bg-gray-900">
+            <img id="modalImage" src="" alt="Magnified Image" class="max-h-[75vh] max-w-[50vw] rounded shadow-lg">
+          </div>
+          <div class="w-64 p-4 bg-gray-100 border-l">
+            <h3 class="font-bold text-lg mb-2">Image Info</h3>
+            <p><strong>Name:</strong> <span id="modalImageName"></span></p>
+            <p><strong>Size:</strong> <span id="modalImageSize"></span></p>
+            <p><strong>Created:</strong> <span id="modalImageCreated"></span></p>
+            <p><strong>Updated:</strong> <span id="modalImageUpdated"></span></p>
+            <div class="mt-3 flex gap-2">
+              <a id="downloadImage" href="#" download class="px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700">Download</a>
+              <button id="closeModal" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    // Reinitialize listeners
+    initImagePreviewModal();
+  }
+
+  function initImagePreviewModal() {
+    var modal = document.getElementById("imageModal");
+    var modalImage = document.getElementById("modalImage");
+    var nameEl = document.getElementById("modalImageName");
+    var sizeEl = document.getElementById("modalImageSize");
+    var createdEl = document.getElementById("modalImageCreated");
+    var updatedEl = document.getElementById("modalImageUpdated");
+    var downloadBtn = document.getElementById("downloadImage");
+    var closeBtn = document.getElementById("closeModal");
+
+    function openModalFromLink(link) {
+      if (!link) return;
+      modalImage.src = link.dataset.imageUrl || "";
+      nameEl.textContent = link.dataset.imageName || "";
+      sizeEl.textContent = link.dataset.imageSize || "";
+      createdEl.textContent = link.dataset.imageCreatedAt || "";
+      updatedEl.textContent = link.dataset.imageUpdatedAt || "";
+
+      var downloadUrl = link.dataset.imageDownloadUrl || link.dataset.imageUrl || "#";
+      downloadBtn.href = downloadUrl;
+      downloadBtn.setAttribute("download", link.dataset.imageName || "image");
+
+      modal.classList.remove("hidden");
+    }
+
+    function closeModal() {
+      modal.classList.add("hidden");
+      setTimeout(function () {
+        modalImage.src = "";
+        reloadImageModal(); // Re-render modal to reset all event listeners!
+      }, 150);
+    }
+
+    document.querySelectorAll(".image-preview-link").forEach(function (link) {
+      link.addEventListener("click", function (e) {
+        e.preventDefault();
+        openModalFromLink(link);
+      });
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener("click", function () {
+        closeModal();
+      });
+    }
+
+    if (modal) {
+      modal.addEventListener("click", function (e) {
+        if (e.target === modal) {
+          closeModal();
+        }
+      });
+    }
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && !modal.classList.contains("hidden")) {
+        closeModal();
+      }
+    });
+  }
+
+  // Initialize on DOM ready and Turbo load
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initImagePreviewModal);
+  } else {
+    initImagePreviewModal();
+  }
+  document.addEventListener("turbo:load", initImagePreviewModal);
+</script>
+
+<style>
+    #imageModal {
+        transition: opacity 0.2s;
+    }
+    #imageModal.hidden {
+        opacity: 0;
+        pointer-events: none;
+    }
+    .image-preview-thumb {
+        transition: transform 0.2s;
+    }
+    .image-preview-thumb:hover {
+        transform: scale(1.08);
+        box-shadow: 0 0 8px #222;
+    }
+</style>

--- a/app/views/defect_messages/_message.html.erb
+++ b/app/views/defect_messages/_message.html.erb
@@ -46,7 +46,7 @@
 
     <!-- Message Content -->
     <div class="prose dark:prose-invert max-w-none <%= message.user == current_user ? 'text-blue-900 dark:text-blue-100' : 'text-gray-700 dark:text-gray-300' %>">
-      <%= message.content.to_s %>
+      <%= render "defect_messages/content_defect_message", message: message %>
     </div>
 
     <!-- Attachments Preview -->

--- a/app/views/defect_messages/_message.html.erb
+++ b/app/views/defect_messages/_message.html.erb
@@ -1,21 +1,22 @@
-<div class="relative pl-8 <%= 'ml-8' if message.user == current_user %>" id="<%= dom_id(message) %>">
-  <!-- Timeline dot - only show for other users' messages -->
-  <% unless message.user == current_user %>
-    <span class="absolute left-0 flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full ring-8 ring-white dark:ring-gray-800 dark:bg-blue-900">
-      <svg class="w-3 h-3 text-blue-800 dark:text-blue-300" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-        <path d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z"/>
-      </svg>
-    </span>
-  <% end %>
-
+<div class="flex items-start space-x-3 w-full" id="<%= dom_id(message) %>">
+  <!-- Timeline dot (icon) -->
+  <span class="flex items-center justify-center w-8 h-8 bg-blue-100 rounded-full dark:bg-blue-900">
+    <svg class="w-4 h-4 text-blue-800 dark:text-blue-300" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+      <path d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z"/>
+    </svg>
+  </span>
+ 
   <!-- Message Card -->
-  <div class="p-4 rounded-lg border shadow-sm max-w-md <%= message.user == current_user ? 'ml-auto bg-blue-50 border-blue-200 dark:bg-blue-900/30 dark:border-blue-700' : 'bg-white border-gray-200 dark:bg-gray-800 dark:border-gray-700' %>">
+  <div class="flex-1 p-4 rounded-lg border shadow-sm 
+              <%= message.user == current_user ? 
+                  'bg-blue-50 border-blue-200 dark:bg-blue-900/30 dark:border-blue-700' : 
+                  'bg-white border-gray-200 dark:bg-gray-800 dark:border-gray-700' %>">
     
     <!-- Message Header -->
     <div class="flex items-center justify-between mb-2">
       <div class="flex items-center gap-3">
         <span class="font-medium text-gray-900 dark:text-white">
-          <%= message.user == current_user ? 'You' : message.user.first_name + ' ' + message.user.last_name %>
+          <%= message.user.first_name + ' ' + message.user.last_name %>
         </span>
         <span class="text-xs text-gray-500 dark:text-gray-400">
           <%= message.created_at.strftime("%I:%M %p") %>
@@ -82,7 +83,6 @@
 </div>
 
 <%= turbo_frame_tag dom_id(message, :edit) %>
-
 
 <script>
   document.addEventListener("turbo:submit-end", function(e) {


### PR DESCRIPTION
In the QA Show page, QA messages are currently displayed side-by-side, similar to a chat/WhatsApp-style view. This layout has been reported as not visually appealing and makes it harder to read long messages.

We need to update the view so that QA messages are instead displayed in a top-to-bottom block layout, where each message takes the full width of the container, stacked one after another.

This PR references issue #98 