### PR TITLE
Page fix for defect home

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -136,7 +136,7 @@ class TasksController < ApplicationController
     end
 
     if @task.prerequisite_task.present? && !@task.prerequisite_task.statuses.exists?(name: 'Resolved')
-      return redirect_to product_task_path(@product, @task), notice: 'Cannot update. Prerequisite task is already resolved.'
+      return redirect_to product_task_path(@product, @task), notice: 'Cannot update, until Prerequisite Task is Resolved.'
     end
 
     @task.statuses.clear

--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -12,7 +12,7 @@
     <% if @defect_groups.present? %>
       <% @defect_groups.each do |group_name, defects| %>
         <!-- Group Header -->
-        <tr class="bg-gray-100 dark:bg-gray-700">
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-left">
           <td class="px-6 py-3 font-semibold text-left">
             <%= link_to "#{group_name.truncate(30)}",
                         index_show_defect_index_path(client_name: defects.first.product.client.name),

--- a/app/views/defect/_top_bar_show.html.erb
+++ b/app/views/defect/_top_bar_show.html.erb
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-2">
   <div class="col-span-1">
     <div class="flex gap-1">
-      <%= button_to root_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100', id: 'button' do %>
+      <%= button_to defect_index_path, method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100', id: 'button' do %>
         &#8656; Back
       <% end %>
 

--- a/app/views/tasks/_add_state.html.erb
+++ b/app/views/tasks/_add_state.html.erb
@@ -11,7 +11,7 @@
                                                     'Awaiting Client API', 'Resolved', 'Closed']) %>
             <% if available_statuses %>
               <%= select_tag :status_id,
-                             options_for_select(available_statuses.pluck(:name, :id)),
+                             options_for_select(available_statuses.pluck(:name, :id), include_blank: true),
                              class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500",
                              required: true %>
             <% end %>


### PR DESCRIPTION
This pull request introduces several small improvements to the user interface and messaging across the tasks and defects features. The changes focus on clarifying user actions, improving feedback messages, and enhancing the visual presentation of defect lists.

**UI/UX Improvements:**

* Updated the group header row styling in the defect listing (`app/views/defect/_defect.html.erb`) to improve readability and visual consistency by adding hover effects, borders, and adjusting background colors.
* Changed the "Back" button in the defect top bar (`app/views/defect/_top_bar_show.html.erb`) to redirect to the defect index page instead of the root path, making navigation more intuitive for users.
* Enhanced the status selection dropdown in the add state task form (`app/views/tasks/_add_state.html.erb`) by including a blank option, allowing users to deselect or leave the status unset.

**Messaging Improvements:**

* Refined the notice message when a prerequisite task is unresolved in the task controller (`app/controllers/tasks_controller.rb`) to be clearer and more instructive for users.