### PR TITLE
Defect Quick View labels error fix

### DIFF
--- a/app/views/defect/_defect_show_modal.html.erb
+++ b/app/views/defect/_defect_show_modal.html.erb
@@ -38,10 +38,23 @@
           </div>
           <div class="text-sm font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider mb-1">
             <p>
-              Content
+              Content:
               <span class="capitalize"><%= @defect.summary %></span>
             </p>
-           Label: <%= @defect.label %>
+            <p>
+              Label(s):
+              <% if @defect.labels.any? %>
+                <div class="flex flex-wrap gap-2">
+                  <% @defect.labels.each do |label| %>
+                    <span class="px-2 py-1 text-xs font-medium bg-gray-200 text-gray-700 rounded dark:bg-gray-600 dark:text-gray-100">
+                      <%= label.name %>
+                    </span>
+                  <% end %>
+                </div>
+              <% else %>
+                <span class="text-xs text-gray-500 italic">No labels</span>
+              <% end %>
+            </p>
           </div>
 
 


### PR DESCRIPTION
Since the defect labels were removed from the defect table, I now get them from the labels table instead