### PR TITLE
Remove unused CKEditor and TomSelect imports from application files

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,8 +7,8 @@ import 'controllers';
 import 'trix';
 import '@rails/actiontext';
 
-import './controllers/ckeditor_init'
-import './controllers/label_tomselect_init'
+/* import './controllers/ckeditor_init' */
+/* import './controllers/label_tomselect_init' */
 
 //= require rails-ujs
 //= require turbolinks

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,6 @@
   <%= favicon_link_tag asset_path('loading.png') %>
   <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <%= javascript_include_tag 'controllers/ckeditor_init' %> or
   <%= javascript_importmap_tags %>
   <% if defined?(Sentry) && ENV["SENTRY_DSN"].present? %>
     <%= Sentry.get_trace_propagation_meta.html_safe %>
@@ -35,11 +34,13 @@
     href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
   />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <!-- CKEditor 5 (Classic build) for advanced rich text + paste from Office/table support -->
+  <!-- CKEditor 5 (Classic build) for advanced rich text + paste from Office/table support
   <script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/classic/ckeditor.js"></script>
-  <!-- TomSelect for Jira-like label field -->
+
+
   <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>
+  -->
 </head>
 <body class="bg-slate-100 dark:bg-gray-900 text-gray-900 dark:text-slate-100">
 <main class="flex">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -12,4 +12,3 @@ pin "tributejs", to: "https://ga.jspm.io/npm:tributejs@5.1.3/dist/tribute.min.js
 pin "@rails/actioncable", to: "actioncable.esm.js"
 pin_all_from "app/javascript/channels", under: "channels"
 #Add CK editor
-pin "ckeditor", to: "https://cdn.ckeditor.com/4.21.0/standard-all/ckeditor.js"


### PR DESCRIPTION
This pull request removes the initialization and loading of the CKEditor and TomSelect libraries from the application, both in the JavaScript entry point and the HTML layout. These changes help clean up unused or commented-out code related to these third-party libraries.

**Removal of CKEditor and TomSelect initialization:**

* Commented out imports for `ckeditor_init` and `label_tomselect_init` controllers in `app/javascript/application.js`, preventing their initialization on the frontend.
* Removed the `javascript_include_tag` for `controllers/ckeditor_init` from `app/views/layouts/application.html.erb`, ensuring it is not loaded in the layout.

**Cleanup of third-party library references:**

* Commented out the CKEditor and TomSelect CDN script and style tags in the HTML layout, so these libraries are no longer loaded from external sources.
* Removed the importmap pin for CKEditor in `config/importmap.rb`, so it is no longer referenced in the asset pipeline.