### PR TITLE
Replace close link with a button to improve modal navigation

### DIFF
--- a/app/views/defect/new.html.erb
+++ b/app/views/defect/new.html.erb
@@ -7,9 +7,14 @@
       <!-- Header -->
       <div class="shrink-0 px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-start">
         <h2 id="new-defect-title" class="text-xl font-semibold text-gray-800 dark:text-white">New Defect</h2>
-        <%= link_to "✕", defect_index_path,
-          data: { turbo_frame: "_top" },
-          class: "ml-auto text-xl font-bold text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded" %>
+
+        <button type="button"
+                class="ml-auto text-xl font-bold text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded cursor-pointer"
+                onclick="history.back()"
+                aria-label="Close modal">
+          X
+        </button>
+
       </div>
       <!-- Form wrapper (flex) -->
       <%= form_with model: @defect, url: defect_index_url, method: :post, data: { turbo: false }, local: true, html: { class: 'flex flex-col grow overflow-hidden', multipart: true } do |f| %>


### PR DESCRIPTION
This pull request updates the modal close button in the `app/views/defect/new.html.erb` file for the "New Defect" page. Instead of using a link to navigate away, it now uses a button that calls `history.back()` to close the modal, improving the user experience by returning users to their previous state.

User interface improvements:

* Replaced the `link_to` close button with a styled `<button>` that uses `history.back()` for navigation, providing a more intuitive modal closing behavior.