### PR TITLE
Add unique_task_id to tasks and update schema

### DIFF
--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -77,31 +77,8 @@ class ProductController < ApplicationController
     if current_user.has_role?('project manager') || current_user.has_role?(:admin) || @product.users.include?(current_user) || current_user.has_role?(:hod)
       @days_remaining = (@product.end_date - Date.today).to_i if @product.end_date.present?
 
-      # Define status groups
-      @open_statuses = ['TO DO', 'In Progress', 'On-Hold', 'Failed-QA', 'QA-testing',
-                        'Await Client Information', 'Reopened',
-                        'Awaiting Build', 'Support Testing', 'Awaiting Client API']
-      @closed_statuses = %w[Blocked Resolved Closed]
-      @awaiting_client_statuses = ['Await Client Information', 'Awaiting Client API']
-
       # Base tasks query with all necessary includes
       @tasks = @product.tasks.includes(:statuses, :users).order(created_at: 'desc')
-
-      # Apply filtering if status param is present
-      if params[:filter].present?
-        case params[:filter]
-        when 'open'
-          @tasks = @tasks.joins(:board).where(boards: { status: @open_statuses })
-        when 'closed'
-          @tasks = @tasks.joins(:board).where(boards: { status: @closed_statuses })
-        when 'awaiting_client'
-          @tasks = @tasks.joins(:board).where(boards: { status: @awaiting_client_statuses })
-        when 'my_open_tasks'
-          @tasks = @tasks.joins(:board, :users)
-            .where(boards: { status: @open_statuses })
-            .where(users: { id: current_user.id })
-        end
-      end
 
       # Apply search query if present
       if params[:query].present?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -103,12 +103,7 @@ class TasksController < ApplicationController
         .set_source('task', @task.id)
         .set_party('user', assigned_user.id)
         .send(queue: true)
-      # Send email to all users tagged on the product, except the current user
-      # @product.users.each do |product_user|
-      #   next if product_user == current_user
 
-      #   UserMailer.task_assignment_email(product_user, @task, current_user, assigned_user).deliver_later
-      # end
 
       redirect_to product_task_path(@product, @task), notice: "#{assigned_user.name} was successfully assigned."
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -54,6 +54,41 @@ class Task < ApplicationRecord
 
   private
 
+  def unique_task_id
+    initials =
+      if product&.client&.name.present?
+        product.client.name.split.map { |word| word[0] }.join.upcase
+      else
+        'DEFAULT'
+      end
+
+    # 👇 include soft-deleted defects
+    last_defect =
+      Task.with_deleted
+            .where(product_id: product_id)
+            .where("defect_unique ~ '^[^-]+-\\d+$'")
+            .order(Arel.sql("CAST(SPLIT_PART(defect_unique, '-', 2) AS INTEGER) DESC"))
+            .first ||
+      Task.with_deleted.where(product_id: product_id).order(:created_at).last
+
+    next_number =
+      if last_defect&.defect_unique.present?
+        last_defect.defect_unique.split('-').last.to_i + 1
+      else
+        1
+      end
+
+    loop do
+      self.defect_unique = "#{initials}-#{next_number.to_s.rjust(4, '0')}"
+      # 👇 check existence including soft-deleted
+      break unless Task.with_deleted.exists?(defect_unique: defect_unique)
+
+      next_number += 1
+    end
+
+    save
+  end
+
   def end_date_after_start_date
     return unless end_date.present? && start_date.present? && end_date < start_date
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
   <%= favicon_link_tag asset_path('loading.png') %>
   <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <%= javascript_include_tag 'controllers/ckeditor_init' %> or
+  <%#= javascript_include_tag 'controllers/ckeditor_init' %> or
   <%= javascript_importmap_tags %>
   <% if defined?(Sentry) && ENV["SENTRY_DSN"].present? %>
     <%= Sentry.get_trace_propagation_meta.html_safe %>
@@ -36,8 +36,8 @@
   />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <!-- CKEditor 5 (Classic build) for advanced rich text + paste from Office/table support -->
-  <script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/classic/ckeditor.js"></script>
-  # <script src="https://cdn.jsdelivr.net/npm/@ckeditor/ckeditor5-build-classic-with-font@41.0.0/build/ckeditor.js"></script>
+
+  <script src="https://cdn.jsdelivr.net/npm/@ckeditor/ckeditor5-build-classic-with-font@41.0.0/build/ckeditor.js"></script>
 
   <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>

--- a/db/migrate/20250909061438_add_task_unique_to_tasks.rb
+++ b/db/migrate/20250909061438_add_task_unique_to_tasks.rb
@@ -1,0 +1,7 @@
+class AddTaskUniqueToTasks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tasks, :unique_task_id, :string, null: true
+    add_index :tasks, :unique_task_id, unique: true, if_not_exists: true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_06_063803) do
-  
+ActiveRecord::Schema[7.2].define(version: 2025_09_09_061438) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -304,7 +303,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_06_063803) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary", null: false
+    t.string "summary"
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.boolean "draft", default: false, null: false
@@ -830,9 +829,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_06_063803) do
     t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da", null: false
     t.uuid "deleted_by"
     t.datetime "deleted_on"
+    t.string "unique_task_id"
     t.index ["deleted_on"], name: "index_tasks_on_deleted_on"
     t.index ["product_id"], name: "index_tasks_on_product_id"
     t.index ["tasks_id"], name: "index_tasks_on_tasks_id"
+    t.index ["unique_task_id"], name: "index_tasks_on_unique_task_id", unique: true
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 


### PR DESCRIPTION
This pull request introduces a unique task identifier system for tasks, updates the database schema to support it, and makes some minor improvements to the frontend and controller logic. The main focus is on generating and storing a unique, human-readable identifier for each task, including handling soft-deleted records. Additionally, there are small code cleanups and frontend updates.

### Unique Task Identifier Feature

* Added a new `unique_task_id` column to the `tasks` table, with a unique index, and updated the schema accordingly. [[1]](diffhunk://#diff-3043918477ab4f333a81107ab506d46ad1a581a440ed972a58d8939f7f67b000R1-R7) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R832-R836)
* Implemented a `unique_task_id` method in `Task` model to generate a unique identifier based on the client initials and an incrementing number, including support for soft-deleted tasks.

### Controller and Model Cleanups

* Removed status-based filtering logic from the `ProductController#show` action to simplify task querying and reduce complexity.
* Removed commented-out code for sending assignment emails in `TasksController#assign_user`.

### Frontend and Asset Updates

* Updated CKEditor script reference in `application.html.erb` to use a newer build with font support, and commented out an unused JavaScript include. [[1]](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebL20-R20) [[2]](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebL39-R40)

### Database Schema Adjustment

* Made the `summary` field in the `tasks` table nullable to allow tasks without a summary.