### PR TITLE
Add task name display to task details view

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -292,13 +292,13 @@ class DefectController < ApplicationController
                   else
                     QaModule.all
                   end
-    
+
     @submodules = if @defect.qa_module
-                # Select only id + name and make the result distinct (and ordered)
-                @defect.qa_module.submodules.select(:id, :name).distinct.order(:name)
-              else
-                QaModule.none
-              end
+                    # Select only id + name and make the result distinct (and ordered)
+                    @defect.qa_module.submodules.select(:id, :name).distinct.order(:name)
+                  else
+                    QaModule.none
+                  end
 
     respond_to do |format|
       format.html

--- a/app/views/tasks/_card.html.erb
+++ b/app/views/tasks/_card.html.erb
@@ -2,9 +2,10 @@
   <div class="flex justify-between mb-2 bg-gray-200 dark:bg-gray-700 p-4 rounded-t-lg">
     <div class="flex items-center gap-4">
       <h3 class="text-lg font-semibold">
-        <% if task.unique_task_id.present? %>
+        <% if task.present? %>
           <%= task.unique_task_id %>
-        <% else %>No ID
+        <% else %>
+          No ID
         <% end %>
       </h3>
     </div>


### PR DESCRIPTION
This pull request makes a minor update to the logic for displaying the task ID in the task card partial. The change ensures that the presence check is performed on the `task` object rather than specifically on its `unique_task_id` attribute.

* Updated the conditional in `app/views/tasks/_card.html.erb` to check if `task` is present before displaying `unique_task_id`, improving robustness in cases where the task object may be nil.