### PR TITLE
Task edit fix

### DIFF
--- a/app/views/tasks/_card.html.erb
+++ b/app/views/tasks/_card.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between mb-2 bg-gray-200 dark:bg-gray-700 p-4 rounded-t-lg">
     <div class="flex items-center gap-4">
       <h3 class="text-lg font-semibold">
-        <% if task.present? %>
+        <% if task.unique_task_id.present? %>
           <%= task.unique_task_id %>
         <% else %>
           No ID

--- a/db/migrate/20250910051707_add_unique_task_id_to_task.rb
+++ b/db/migrate/20250910051707_add_unique_task_id_to_task.rb
@@ -1,0 +1,6 @@
+class AddUniqueTaskIdToTask < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tasks, :unique_task_id, :string, null: false,  if_not_exists: true
+    add_index :tasks, :unique_task_id, unique: true, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_06_063803) do
-  
+ActiveRecord::Schema[7.2].define(version: 2025_09_10_051707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -304,7 +303,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_06_063803) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary", null: false
+    t.string "summary"
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.boolean "draft", default: false, null: false
@@ -830,9 +829,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_06_063803) do
     t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da", null: false
     t.uuid "deleted_by"
     t.datetime "deleted_on"
+    t.string "unique_task_id"
     t.index ["deleted_on"], name: "index_tasks_on_deleted_on"
     t.index ["product_id"], name: "index_tasks_on_product_id"
     t.index ["tasks_id"], name: "index_tasks_on_tasks_id"
+    t.index ["unique_task_id"], name: "index_tasks_on_unique_task_id", unique: true
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 


### PR DESCRIPTION
This pull request introduces a new `unique_task_id` field to the `tasks` table, ensures its visibility in the UI, and updates the database schema accordingly. It also relaxes the `null: false` constraint on the `summary` field in the `tasks` table. The main changes are grouped below:

**Database schema changes:**

* Added a new migration (`20250910051707_add_unique_task_id_to_task.rb`) that introduces the `unique_task_id` column to the `tasks` table, sets it as non-nullable, and creates a unique index for it. (`[db/migrate/20250910051707_add_unique_task_id_to_task.rbR1-R6](diffhunk://#diff-8dcf8e3cf5c7cdec363f5c3afb80b33185775ed0125a0ca4d77df7bd5ef64c42R1-R6)`)
* Updated `db/schema.rb` to reflect the addition of the `unique_task_id` column and its unique index in the `tasks` table. (`[db/schema.rbR832-R836](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R832-R836)`)
* Changed the `summary` column in the `tasks` table to allow null values instead of requiring a value. (`[db/schema.rbL307-R306](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L307-R306)`)
* Updated the schema version to `2025_09_10_051707` to match the new migration. (`[db/schema.rbL13-R13](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13)`)

**UI changes:**

* Modified the task card partial (`_card.html.erb`) to display the `unique_task_id` if present, otherwise show "No ID". (`[app/views/tasks/_card.html.erbL5-R5](diffhunk://#diff-031c870f91b82dd6e8fdcc805d33511418bf103f5256588aaf1e678178c175dcL5-R5)`)