### PR TITLE
Retesting Failure Reporting in Defects

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -1,6 +1,6 @@
 class DefectController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_defect, only: %i[show edit update update_priority destroy add_defect add_attachments remove_attachment update_label modal_show add_label remove_label]
+  before_action :set_defect, only: %i[show edit update update_priority destroy add_defect add_attachments remove_attachment update_label modal_show add_label remove_label defect_status create_failure_report]
 
   def index
     # Load defects with needed associations
@@ -437,15 +437,80 @@ class DefectController < ApplicationController
   end
 
   def defect_status
-    @defect = Defect.find(params[:id])
     status = Status.find(params[:status_id])
-    @defect.statuses.clear
-    @defect.statuses << status
-    redirect_to defect_path(@defect), notice: 'Product status was successfully updated.'
+
+    if status.name.strip.downcase == "failed qa"
+      # DO NOT persist the status yet; we need a reason
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "modal",
+            partial: "defect/failure_reason_modal",
+            locals: { defect: @defect }
+          )
+        end
+        format.html { redirect_to defect_path(@defect), alert: "Failed QA requires a reason." }
+      end
+      return
+    end
+
+    # Non-Failed QA: commit the status change now
+    @defect.transaction do
+      @defect.statuses.clear
+      @defect.statuses << status
+    end
+
     log_event(
       @defect, current_user, 'Status Changed',
-      status.present? ? "Defect Status was changed to #{status.name} by #{current_user.name} at #{Time.now.strftime('%H:%M of  %d-%m-%Y')}" : "Defect was Updated but no assigned user at #{Time.now.strftime('%H:%M of  %d-%m-%Y')}"
+      "Defect Status was changed to #{status.name} by #{current_user.name} at #{Time.now.strftime('%H:%M of %d-%m-%Y')}"
     )
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace("modal", partial: "defect/modal_empty"),
+          turbo_stream.replace("defect_status_#{@defect.id}", partial: "defect/status_badge", locals: { defect: @defect })
+        ]
+      end
+      format.html { redirect_to defect_path(@defect), notice: "Defect status was successfully updated." }
+    end
+  end
+
+  # POST /defect/:id/create_failure_report
+  def create_failure_report
+    authorize_view_failure_reports!
+
+    reason_html = params.dig(:defect_failure_report, :reason)
+
+    begin
+      report = DefectRecordFailureService.new(defect: @defect, actor: current_user, reason_html: reason_html).call
+
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.replace("modal", partial: "defect/modal_empty"),
+            turbo_stream.replace("defect_status_#{@defect.id}", partial: "defect/status_badge", locals: { defect: @defect }),
+          ]
+        end
+
+        format.html { redirect_to defect_path(@defect), notice: "Failure reason recorded successfully." }
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      @failure_report = e.record
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "modal",
+            partial: "defect/failure_reason_modal",
+            locals: { defect: @defect, failure_report: @failure_report }
+          ), status: :unprocessable_entity
+        end
+        format.html do
+          flash.now[:alert] = "Could not save failure reason: #{@failure_report.errors.full_messages.join(', ')}"
+          render :show, status: :unprocessable_entity
+        end
+      end
+    end
   end
 
   def remove_defect
@@ -557,6 +622,12 @@ class DefectController < ApplicationController
 
   private
 
+  def authorize_view_failure_reports!
+    unless current_user.has_role?(:qa) || current_user.has_role?(:hod) || current_user.has_role?(:admin)
+      redirect_to defect_path(@defect), notice: "You are not authorized to view failure reports."
+    end
+  end
+
   def set_form_data
     @qa_modules = QaModule.where(parent_id: nil)
     @banking_types = BankingType.all
@@ -606,6 +677,7 @@ class DefectController < ApplicationController
       :draft,
       :product_id,
       :issue_type,
+      :retest_count,
       :defect_unique,
       user_ids: [],
       label_ids: [],

--- a/app/controllers/defect_failure_reports_controller.rb
+++ b/app/controllers/defect_failure_reports_controller.rb
@@ -1,0 +1,36 @@
+class DefectFailureReportsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_defect
+  before_action :authorize_view!
+
+  def index
+    @reports = @defect.defect_failure_reports.visible.order(retest_number: :asc)
+    respond_to do |format|
+      format.html
+      format.json { render json: @reports.as_json(only: %i[id retest_number captured_at created_at]) }
+    end
+  end
+
+  def show
+    @report = @defect.defect_failure_reports.find(params[:id])
+  end
+
+  private
+
+  def set_defect
+    if params[:defect_id].present?
+      @defect = Defect.find(params[:defect_id])
+    elsif params[:id].present?
+      report = DefectFailureReport.find_by(id: params[:id])
+      @defect = report&.defect
+    else
+      head :bad_request
+    end
+  end
+
+  def authorize_view!
+    unless current_user.has_role?(:qa) || current_user.has_role?(:hod) || current_user.has_role?(:admin)
+      render plain: "Not authorized", status: :forbidden
+    end
+  end
+end

--- a/app/javascript/controllers/status_selector_controller.js
+++ b/app/javascript/controllers/status_selector_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["select"]
+
+  connect() {
+    this.select = this.hasSelectTarget ? this.selectTarget : this.element.querySelector("select")
+  }
+
+  // wired with data-action="change->status-selector#change"
+  change(event) {
+    event.preventDefault()
+    const form = this.element.tagName === "FORM" ? this.element : this.select.closest("form")
+    if (!form) return console.error("status-selector: form not found")
+
+    const tokenEl = document.querySelector("meta[name='csrf-token']")
+    const token = tokenEl ? tokenEl.getAttribute("content") : ""
+
+    fetch(form.action, {
+      method: (form.method || "post").toUpperCase(),
+      headers: {
+        "Accept": "text/vnd.turbo-stream.html",
+        "X-CSRF-Token": token
+      },
+      body: new URLSearchParams(new FormData(form)),
+      credentials: "same-origin"
+    })
+    .then(response => {
+      if (!response.ok) throw new Error("Network response was not ok")
+      return response.text()
+    })
+    .then(body => {
+      // Let Turbo apply the returned turbo-streams
+      if (window.Turbo && Turbo.renderStreamMessage) {
+        Turbo.renderStreamMessage(body)
+      } else {
+        // Fallback: replace #modal with returned HTML (non-stream)
+        const modal = document.getElementById("modal")
+        if (modal) modal.innerHTML = body
+      }
+    })
+    .catch(err => {
+      console.error("status-selector change failed:", err)
+      // optional: show toast/notice
+    })
+  }
+}

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -14,6 +14,7 @@ class Defect < ApplicationRecord
 
   has_many :defect_labels, dependent: :destroy
   has_many :labels, through: :defect_labels
+  has_many :defect_failure_reports, dependent: :destroy
 
   resourcify
   has_many :users, through: :roles, class_name: 'User', source: :users

--- a/app/models/defect_failure_report.rb
+++ b/app/models/defect_failure_report.rb
@@ -1,0 +1,10 @@
+class DefectFailureReport < ApplicationRecord
+  # Associations
+  belongs_to :defect
+
+  has_rich_text :reason
+
+  # Validations
+  validates :retest_number, presence: true
+  validates :captured_at, presence: true
+end

--- a/app/services/defect_record_failure_service.rb
+++ b/app/services/defect_record_failure_service.rb
@@ -1,0 +1,55 @@
+class DefectRecordFailureService
+  def initialize(defect:, actor:, reason_html: nil)
+    @defect = defect
+    @actor = actor
+    @reason_html = reason_html
+  end
+
+  def call
+    @defect.transaction do
+      @defect.lock!
+
+      failed_status = Status.where("lower(name) = ?", "failed qa").first || Status.find_by(name: "Failed QA")
+      if failed_status
+        @defect.statuses.clear
+        @defect.statuses << failed_status
+      end
+
+      @defect.retest_count = @defect.retest_count.to_i + 1
+      @defect.save!
+
+      report = DefectFailureReport.create!(
+        defect: @defect,
+        retest_number: @defect.retest_count,
+        captured_at: Time.current,
+        created_by_id: @actor&.id
+      )
+
+      # store HTML into ActionText rich text
+      report.reason = @reason_html.presence || "<p>No QA comment provided</p>"
+      report.save!
+
+      create_history_and_activity(report)
+
+      report
+    end
+  end
+
+  private
+
+  def create_history_and_activity(report)
+    # create timeline entry
+    DefectHistory.create!(
+      defect: @defect,
+      user: @actor,
+      history_type: 'QA Failed (retest recorded)',
+      history: "Retest ##{report.retest_number} recorded at #{report.captured_at.strftime('%Y-%m-%d %H:%M')}"
+    )
+    # audit activity, wrap in rescue in your production code as needed
+    activity('user_activity').caused_by(@actor).performed_on(@defect)
+      .event('defect.retest_recorded').with_properties(retest_number: report.retest_number)
+      .log("Defect ##{@defect.id} marked QA Failed — retest ##{report.retest_number}")
+  rescue => e
+    Rails.logger.error("DefectRecordFailureService: logging failure: #{e.message}")
+  end
+end

--- a/app/views/defect/_assign_defect_status.html.erb
+++ b/app/views/defect/_assign_defect_status.html.erb
@@ -1,26 +1,17 @@
-<%# Fetch all statuses you want in the dropdown %>
 <%
   status_options = Status.where(name: [
-    'TO DO',
-    'In Progress',
-    'On-Hold',
-    'Awaiting Client Info',
-    'Awaiting Build',
-    'QA Testing',
-    'Closed',
-    'Failed QA',
-    'Blocked',
-    'Reopened'
+    'TO DO','In Progress','On-Hold','Awaiting Client Info',
+    'Awaiting Build','QA Testing','Closed','Failed QA','Blocked','Reopened'
   ]).pluck(:name, :id)
 %>
 
 <% unless @defect.statuses.first&.name == 'End Of Production' %>
-  <%= form_with url: defect_status_defect_path(@defect), local: true, method: :post do %>
+  <%= form_with url: defect_status_defect_path(@defect), method: :post, local: false, data: { controller: "status-selector" } do %>
     <div class="relative flex flex-col gap-2 mt-2">
       <%= select_tag :status_id,
-                     options_for_select(status_options, @defect.statuses.first&.id),
-                     onchange: "this.form.submit()",
-                     class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
+            options_for_select(status_options, @defect.statuses.first&.id),
+            data: { action: "change->status-selector#change", status_selector_target: "select" },
+            class: "border border-gray-300 rounded-lg p-2.5 dark:bg-gray-700 dark:border-gray-600" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/defect/_failure_reason_modal.html.erb
+++ b/app/views/defect/_failure_reason_modal.html.erb
@@ -1,0 +1,29 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+    <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-2xl relative">
+      <%= link_to "✕", defect_path(defect), data: { turbo_frame: "_top" }, class: "absolute top-3 right-3 text-xl font-bold text-gray-500" %>
+
+      <h2 class="text-lg font-semibold mb-2 dark:text-gray-200">Record QA Failure</h2>
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        Kindly fill in this form for future reference. This helps you, other QA engineers, and developers
+        understand why this defect failed QA and what caused it.
+      </p>
+
+      <%= form_with model: [defect, DefectFailureReport.new], 
+                    url: create_failure_report_defect_path(defect),
+                    method: :post, local: false do |f| %>
+        <div class="mb-4">
+          <%= f.label :reason, "Explain the failure", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+          <%= f.rich_text_area :reason, id: "failure_reason_textarea_#{defect.id}",
+                placeholder: "Provide details on why this defect failed QA...",
+                class: "w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:text-white" %>
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <%= f.submit "Submit Report", class: "px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700" %>
+          <%= link_to "Cancel", defect_path(defect), data: { turbo_frame: "_top" }, class: "px-4 py-2 bg-gray-300 rounded-lg hover:bg-gray-400" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/defect/_modal_empty.html.erb
+++ b/app/views/defect/_modal_empty.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_frame_tag "modal" do %>
+  <!-- empty modal placeholder; keep it blank so modal area is cleared -->
+  <div></div>
+<% end %>

--- a/app/views/defect/_status_badge.html.erb
+++ b/app/views/defect/_status_badge.html.erb
@@ -1,0 +1,8 @@
+<span id="defect_status_<%= defect.id %>" class="px-2 py-1 text-xs font-semibold rounded
+  <%= case defect.statuses.first&.name
+       when "Failed QA" then "bg-red-100 text-red-800"
+       when "Closed"    then "bg-green-100 text-green-800"
+       else "bg-gray-100 text-gray-800"
+     end %>">
+  <%= defect.statuses.first&.name || "No Status" %>
+</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
   end
 
   resources :defect do
+    resources :defect_failure_reports, only: [:index, :show], controller: 'defect_failure_reports'
     resources :defect_messages, only: [:new, :create, :edit, :update, :destroy]
     post 'attachments', to: 'defect#add_attachments', as: 'attachments'
     delete 'attachments/:attachment_id', to: 'defect#remove_attachment', as: 'attachment'
@@ -130,6 +131,7 @@ Rails.application.routes.draw do
       post :add_defect
       delete :remove_defect
       post :defect_status
+      post :create_failure_report
       patch 'update_priority'
       patch 'update_label'
     end

--- a/db/migrate/20250910074611_add_retest_count_to_defects.rb
+++ b/db/migrate/20250910074611_add_retest_count_to_defects.rb
@@ -1,0 +1,5 @@
+class AddRetestCountToDefects < ActiveRecord::Migration[7.2]
+  def change
+    add_column :defects, :retest_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20250910080959_create_defect_failure_reports.rb
+++ b/db/migrate/20250910080959_create_defect_failure_reports.rb
@@ -1,0 +1,27 @@
+class CreateDefectFailureReports < ActiveRecord::Migration[7.2]
+  def change
+    create_table :defect_failure_reports, id: :uuid do |t|
+      t.uuid    :defect_id, null: false
+      t.integer :retest_number, null: false
+      t.datetime :captured_at, null: false
+
+      # audit / soft delete / archive fields
+      t.references :created_by,  type: :uuid, foreign_key: { to_table: :users }
+      t.references :modified_by, type: :uuid, foreign_key: { to_table: :users }
+      t.references :deleted_by,  type: :uuid, foreign_key: { to_table: :users }
+      t.datetime :deleted_on
+
+      t.boolean :archive_status, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :defect_failure_reports, :defect_id
+    add_index :defect_failure_reports, :retest_number
+    add_index :defect_failure_reports, :archive_status
+    add_index :defect_failure_reports, :deleted_on
+
+    # Foreign key to defects
+    add_foreign_key :defect_failure_reports, :defects, column: :defect_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_10_074611) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_10_080959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -230,6 +230,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_10_074611) do
     t.index ["deleted_on"], name: "index_default_defect_assignees_on_deleted_on"
     t.index ["modified_by_id"], name: "index_default_defect_assignees_on_modified_by_id"
     t.index ["user_id"], name: "index_default_defect_assignees_on_user_id", unique: true
+  end
+
+  create_table "defect_failure_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "defect_id", null: false
+    t.integer "retest_number", null: false
+    t.datetime "captured_at", null: false
+    t.uuid "created_by_id"
+    t.uuid "modified_by_id"
+    t.uuid "deleted_by_id"
+    t.datetime "deleted_on"
+    t.boolean "archive_status", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["archive_status"], name: "index_defect_failure_reports_on_archive_status"
+    t.index ["created_by_id"], name: "index_defect_failure_reports_on_created_by_id"
+    t.index ["defect_id"], name: "index_defect_failure_reports_on_defect_id"
+    t.index ["deleted_by_id"], name: "index_defect_failure_reports_on_deleted_by_id"
+    t.index ["deleted_on"], name: "index_defect_failure_reports_on_deleted_on"
+    t.index ["modified_by_id"], name: "index_defect_failure_reports_on_modified_by_id"
+    t.index ["retest_number"], name: "index_defect_failure_reports_on_retest_number"
   end
 
   create_table "defect_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1007,6 +1027,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_10_074611) do
   add_foreign_key "default_defect_assignees", "users", column: "created_by_id"
   add_foreign_key "default_defect_assignees", "users", column: "deleted_by_id"
   add_foreign_key "default_defect_assignees", "users", column: "modified_by_id"
+  add_foreign_key "defect_failure_reports", "defects"
+  add_foreign_key "defect_failure_reports", "users", column: "created_by_id"
+  add_foreign_key "defect_failure_reports", "users", column: "deleted_by_id"
+  add_foreign_key "defect_failure_reports", "users", column: "modified_by_id"
   add_foreign_key "defect_histories", "defects"
   add_foreign_key "defect_histories", "users"
   add_foreign_key "defect_messages", "defects"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_10_051707) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_10_074611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -303,10 +303,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_10_051707) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary"
+    t.string "summary", null: false
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.boolean "draft", default: false, null: false
+    t.integer "retest_count", default: 0, null: false
     t.index ["banking_type_id"], name: "index_defects_on_banking_type_id"
     t.index ["creator_id"], name: "index_defects_on_creator_id"
     t.index ["defect_unique"], name: "index_defects_on_defect_unique", unique: true


### PR DESCRIPTION
Add a functionality where, when a user changes the status of the defect to Failed QA, they get a pop-up modal that asks them to add a text of why the defect failed QA for future reference. When they do so, the status changes and the retest cont is updated

This works in this issue #205 