### PR TITLE
Refactor schema by removing unused tables and updating action mailer …

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -77,10 +77,8 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_mailer.default_url_options = { host: 'craftsilicon.com', protocol: 'http' }
+  config.action_mailer.default_url_options = { host: 'taskbridge.craftsilicon.com', protocol: 'https' }
   config.action_controller.raise_on_missing_callback_actions = true
-  config.action_mailer.default_url_options = { host: 'http://172.16.2.15' }
-  config.active_storage.variant_processor = :mini_magick
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,18 +30,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
-  create_table "action_text_tables", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "content", default: [["", ""], ["", ""]], null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "action_text_tables_table", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "content", default: [["", ""], ["", ""]], null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -318,7 +306,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.uuid "deleted_by_id"
     t.datetime "deleted_on"
     t.boolean "archive_status", default: false, null: false
-    t.text "content"
     t.index ["archive_status"], name: "index_defect_messages_on_archive_status"
     t.index ["created_by_id"], name: "index_defect_messages_on_created_by_id"
     t.index ["defect_id"], name: "index_defect_messages_on_defect_id"
@@ -358,10 +345,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.string "summary"
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
-    t.text "labels", default: [], array: true
     t.boolean "draft", default: false, null: false
     t.integer "retest_count", default: 0, null: false
-    t.boolean "linkage_blocked", default: false, null: false
     t.index ["banking_type_id"], name: "index_defects_on_banking_type_id"
     t.index ["creator_id"], name: "index_defects_on_creator_id"
     t.index ["defect_unique"], name: "index_defects_on_defect_unique", unique: true
@@ -810,21 +795,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.index ["script_id"], name: "index_products_on_script_id"
     t.index ["software_id"], name: "index_products_on_software_id"
     t.index ["user_id"], name: "index_products_on_user_id"
-  end
-
-  create_table "products_qa_modules", id: false, force: :cascade do |t|
-    t.uuid "product_id", null: false
-    t.uuid "qa_module_id", null: false
-    t.uuid "created_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da"
-    t.uuid "modified_by", default: "c5d5cc2c-5ab2-4301-811a-5b6e8e4f61da"
-    t.uuid "deleted_by"
-    t.datetime "deleted_on"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["deleted_on"], name: "index_products_qa_modules_on_deleted_on"
-    t.index ["product_id", "qa_module_id"], name: "index_products_qa_modules_on_product_id_and_qa_module_id", unique: true
-    t.index ["product_id"], name: "index_products_qa_modules_on_product_id"
-    t.index ["qa_module_id"], name: "index_products_qa_modules_on_qa_module_id"
   end
 
   create_table "products_scripts", id: false, force: :cascade do |t|


### PR DESCRIPTION
…URL configuration
This pull request primarily removes unused or obsolete database tables and columns from the schema, and updates mailer configuration for the staging environment. These changes help clean up the codebase and improve security and maintainability.

**Configuration update:**

* Changed `action_mailer.default_url_options` in `config/environments/staging.rb` to use the secure `https` protocol and the correct subdomain for staging emails.

**Database schema cleanup:**

* Removed the `action_text_tables` and `action_text_tables_table` tables from `db/schema.rb`, indicating these tables are no longer needed.
* Dropped the `products_qa_modules` join table from `db/schema.rb`, suggesting a change in how products and QA modules are related or managed.

**Defect-related model simplification:**

* Removed the `content` column from the `defect_messages` table and the `labels` and `linkage_blocked` columns from the `defects` table in `db/schema.rb`, streamlining these models. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L321) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L361-L364)