### PR TITLE
Usermailer/defects

### DIFF
--- a/app/controllers/defect_messages_controller.rb
+++ b/app/controllers/defect_messages_controller.rb
@@ -40,9 +40,9 @@ class DefectMessagesController < ApplicationController
     @defect_message.user = current_user
 
     if @defect_message.save
-      # Process mentions asynchronously - pass the ActionText content directly
+      # Process mentions asynchronously - convert ActionText to HTML string for job serialization
       ProcessMentionsJob.perform_later(
-        @defect_message.content,
+        @defect_message.content.body.to_html,
         @defect.id,
         current_user.id,
         'message'
@@ -65,9 +65,9 @@ class DefectMessagesController < ApplicationController
   def update
     audit_on_update(@defect_message)
     if @defect_message.update(defect_message_params)
-      # Process mentions asynchronously for updated message - pass the ActionText content directly
+      # Process mentions asynchronously for updated message - convert ActionText to HTML string for job serialization
       ProcessMentionsJob.perform_later(
-        @defect_message.content,
+        @defect_message.content.body.to_html,
         @defect.id,
         current_user.id,
         'message'

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -227,4 +227,17 @@ class UserMailer < ApplicationMailer
     @url = defect_url(@defect)
     mail(to: assigned_emails + [creator.email], subject: 'Edit Defect')
   end
+
+  def defect_mention_notification(user, defect, current_user, content, context_type = 'message')
+    @user = user
+    @defect = defect
+    @current_user = current_user
+    @content = content
+    @context_type = context_type
+    @url = defect_url(@defect)
+    @context_text = context_type == 'message' ? 'comment' : 'defect'
+
+    subject = "You were mentioned in a #{@context_text} on defect #{@defect.defect_unique}"
+    mail(to: @user.email, subject: subject)
+  end
 end

--- a/app/services/mention_notification_service.rb
+++ b/app/services/mention_notification_service.rb
@@ -67,21 +67,13 @@ class MentionNotificationService
   end
 
   def send_mention_notification(user)
-    subject = build_email_subject
-    body = build_email_body(user)
-
-    Messaging::EmailSender
-      .send_email(
-        subject,
-        to: [user.email],
-        body: body,
-        actor: @current_user,
-        priority: :normal,
-        type: 'defect_mention'
-      )
-      .set_source('Defect', @defect.id)
-      .set_party('User', user.id)
-      .send(queue: true)
+    UserMailer.defect_mention_notification(
+      user,
+      @defect,
+      @current_user,
+      @content,
+      @context_type
+    ).deliver_now
   rescue StandardError => e
     Rails.logger.error "Failed to send mention notification to #{user.email}: #{e.message}"
     ErrorLogger.log(e, context: {
@@ -90,67 +82,6 @@ class MentionNotificationService
                       current_user_id: @current_user.id,
                       context_type: @context_type
                     })
-  end
-
-  def build_email_subject
-    context_text = @context_type == 'message' ? 'comment' : 'defect'
-    "You were mentioned in a #{context_text} on defect #{@defect.defect_unique}"
-  end
-
-  def build_email_body(user)
-    defect_url = Rails.application.routes.url_helpers.defect_url(@defect)
-
-    context_text = @context_type == 'message' ? 'comment' : 'defect description'
-
-    <<~HTML
-      <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
-        <h2 style="color: #2563eb;">You've been mentioned!</h2>
-
-        <p>Hi #{user.first_name},</p>
-
-        <p><strong>#{@current_user.first_name} #{@current_user.last_name}</strong> mentioned you in a #{context_text} on defect:</p>
-
-        <div style="background-color: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 16px; margin: 16px 0;">
-          <h3 style="margin-top: 0; color: #1f2937;">#{@defect.defect_unique}: #{@defect.summary}</h3>
-          <p><strong>Priority:</strong> #{@defect.priority}</p>
-          <p><strong>Product:</strong> #{get_product_display_name}</p>
-          #{build_content_preview}
-        </div>
-
-        <div style="margin: 24px 0;">
-          <a href="#{defect_url}"
-             style="background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
-            View Defect
-          </a>
-        </div>
-
-        <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 24px 0;">
-
-        <p style="font-size: 12px; color: #6b7280;">
-          This notification was sent because you were mentioned in TaskBridge.
-          <br>Reply directly to this email or click the link above to respond.
-        </p>
-      </div>
-    HTML
-  end
-
-  def build_content_preview
-    return '' unless @content.present?
-
-    # Extract plain text for preview (remove HTML tags and mentions)
-    content_text = ActionController::Base.helpers.strip_tags(extract_html_content(@content))
-    content_text = content_text.gsub(/@[^\s]+/, '').gsub(/#[^\s]+/, '').strip
-
-    # Limit to first 200 characters
-    preview = content_text.length > 200 ? "#{content_text[0..197]}..." : content_text
-
-    return '' if preview.blank?
-
-    <<~HTML
-      <div style="margin-top: 12px; padding-top: 12px; border-top: 1px solid #e2e8f0;">
-        <p style="font-style: italic; margin: 0;">#{preview}</p>
-      </div>
-    HTML
   end
 
   def create_activity_log(user)
@@ -165,23 +96,6 @@ class MentionNotificationService
         defect_unique: @defect.defect_unique
       )
       .log("Mentioned #{user.first_name} #{user.last_name} in #{@context_type} on Defect ##{@defect.id}")
-  end
-
-  def get_product_display_name
-    return 'Unknown Product' unless @defect.product
-
-    # Try different attributes to get a meaningful product name
-    product = @defect.product
-
-    if product.document_name.present?
-      product.document_name
-    elsif product.respond_to?(:name) && product.name.present?
-      product.name
-    elsif product.respond_to?(:title) && product.title.present?
-      product.title
-    else
-      "Product ##{product.id.to_s[0..7]}"
-    end
   end
 
   class << self

--- a/app/views/user_mailer/defect_mention_notification.html.erb
+++ b/app/views/user_mailer/defect_mention_notification.html.erb
@@ -1,0 +1,35 @@
+<div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+  <h2 style="color: #2563eb;">You've been mentioned!</h2>
+
+  <p>Hi <%= @user.first_name %>,</p>
+
+  <p><strong><%= @current_user.first_name %> <%= @current_user.last_name %></strong> mentioned you in a <%= @context_text %> on defect:</p>
+
+  <div style="background-color: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 16px; margin: 16px 0;">
+    <h3 style="margin-top: 0; color: #1f2937;"><%= @defect.defect_unique %>: <%= @defect.summary %></h3>
+    <p><strong>Priority:</strong> <%= @defect.priority %></p>
+    <p><strong>Product:</strong> <%= @defect.product&.document_name || 'Unknown Product' %></p>
+    
+    <% if @content.present? %>
+      <% content_text = strip_tags(@content.to_s).gsub(/@[^\s]+/, '').gsub(/#[^\s]+/, '').strip %>
+      <% if content_text.present? %>
+        <% preview = content_text.length > 200 ? "#{content_text[0..197]}..." : content_text %>
+        <div style="margin-top: 12px; padding-top: 12px; border-top: 1px solid #e2e8f0;">
+          <p style="font-style: italic; margin: 0;"><%= preview %></p>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div style="margin: 24px 0;">
+    <%= link_to "View Defect", @url, 
+        style: "background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;" %>
+  </div>
+
+  <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 24px 0;">
+
+  <p style="font-size: 12px; color: #6b7280;">
+    This notification was sent because you were mentioned in TaskBridge.
+    <br>Reply directly to this email or click the link above to respond.
+  </p>
+</div>

--- a/app/views/user_mailer/defect_mention_notification.text.erb
+++ b/app/views/user_mailer/defect_mention_notification.text.erb
@@ -1,0 +1,25 @@
+You've been mentioned!
+
+Hi <%= @user.first_name %>,
+
+<%= @current_user.first_name %> <%= @current_user.last_name %> mentioned you in a <%= @context_text %> on defect:
+
+<%= @defect.defect_unique %>: <%= @defect.summary %>
+Priority: <%= @defect.priority %>
+Product: <%= @defect.product&.document_name || 'Unknown Product' %>
+
+<% if @content.present? %>
+<% content_text = strip_tags(@content.to_s).gsub(/@[^\s]+/, '').gsub(/#[^\s]+/, '').strip %>
+<% if content_text.present? %>
+<% preview = content_text.length > 200 ? "#{content_text[0..197]}..." : content_text %>
+
+Content preview:
+<%= preview %>
+<% end %>
+<% end %>
+
+View Defect: <%= @url %>
+
+--
+This notification was sent because you were mentioned in TaskBridge.
+Reply directly to this email or visit the link above to respond.


### PR DESCRIPTION
This pull request refactors how mention notifications are sent for defect messages, moving from a custom email sender to using ActionMailer with new email templates. It also ensures that ActionText content is properly serialized as HTML when processing mentions asynchronously. The main changes are grouped below:

**Mention Notification Delivery Refactor:**

* Replaced the custom `Messaging::EmailSender` logic in `MentionNotificationService` with the new `UserMailer.defect_mention_notification` ActionMailer method, simplifying email delivery and making it more maintainable.
* Removed custom subject and body building methods from `MentionNotificationService`, delegating all email content generation to the mailer and its view templates. [[1]](diffhunk://#diff-6cc4e816a52866368a053e350d6adaba3873d2ca9c0581d8ad8adb58125a8a9cL95-L155) [[2]](diffhunk://#diff-6cc4e816a52866368a053e350d6adaba3873d2ca9c0581d8ad8adb58125a8a9cL170-L186)

**ActionMailer Integration and Templates:**

* Added a new mailer method `defect_mention_notification` to `UserMailer`, which sets up all necessary instance variables and subject lines for mention notifications.
* Created new HTML and text email templates (`defect_mention_notification.html.erb` and `defect_mention_notification.text.erb`) for mention notifications, including user-friendly formatting and a content preview. [[1]](diffhunk://#diff-3ac471691cb5facdd74d0e0c2bc669d7736f19a801726cd1a263b1aebcfdca22R1-R35) [[2]](diffhunk://#diff-425acf74a42e2dd7e1f8fd31be0e9e32f35cb17494be0cef4c17ba1d5e979b1aR1-R25)

**Controller Serialization Fixes:**

* Updated `defect_messages_controller.rb` to serialize ActionText content as HTML (`content.body.to_html`) before passing it to the mention processing job, ensuring proper formatting in notifications. [[1]](diffhunk://#diff-9e670538fa3b806647c65cc66ba0102ce106cfa6ddc0f5be85b086848f0d86a8L43-R45) [[2]](diffhunk://#diff-9e670538fa3b806647c65cc66ba0102ce106cfa6ddc0f5be85b086848f0d86a8L68-R70)