### PR TITLE
Email staging

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,14 @@
 # app/mailers/user_mailer.rb
 class UserMailer < ApplicationMailer
-  default from: 'cspm@craftsilicon.com'
+  default from: (
+    if Rails.env.staging?
+      'taskbridgestaging@craftsilicon.com'
+    elsif Rails.env.production?
+      'cspm@craftsilicon.com'
+    else
+      'cspm@craftsilicon.com'
+    end
+  )
   # From Project Controller
   def assignment_email(user, project, current_user, assigned_user)
     @user = user

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_mailer.default_url_options = { host: 'taskbridge.craftsilicon.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: 'http://172.16.2.15/', protocol: 'http' }
   config.action_controller.raise_on_missing_callback_actions = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
This pull request updates the default sender email address in the `UserMailer` to use a different address for the staging environment. This helps ensure that emails sent from staging are easily distinguishable from those sent from production.

Email configuration update:

* Changed the default `from` address in `user_mailer.rb` to use `taskbridgestaging@craftsilicon.com` in staging and `cspm@craftsilicon.com` in production and other environments.