### PR TITLE
Aggregate client rating for service desk

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,6 +40,17 @@ class Project < ApplicationRecord
   end
   # To have pick a list of users who have role agent only on a dropdown list at the view to assign a project
 
+  def average_servicedesk_rating
+    feedbacks = TicketFeedback.joins(:ticket).where(tickets: { project_id: id })
+    return nil if feedbacks.empty?
+
+    feedbacks.average(:rating).to_f.round(1)
+  end
+
+  def has_ratings?
+    TicketFeedback.joins(:ticket).where(tickets: { project_id: id }).exists?
+  end
+
   private
 
   def content_length_within_limit

--- a/app/views/project/_project_table.html.erb
+++ b/app/views/project/_project_table.html.erb
@@ -6,6 +6,7 @@
       <th scope="col" class="px-4 py-2">Name of Project</th>
       <th scope="col" class="px-4 px-2">Project Description</th>
       <th scope="col" class="px-4 px-2">Total Tickets</th>
+      <th scope="col" class="px-4 px-2">Average Rating</th>
       <th scope="col" class="px-4 px-2">Assignee</th>
       <th scope="col" class="px-4 px-2">Client</th>
       <th scope="col" class="px-4 px-2">Product Category</th>
@@ -35,6 +36,9 @@
             </td>
             <td class="px-4 py-4 text-center">
               <%= project.tickets.count %>
+            </td>
+            <td class="px-4 py-4 text-center">
+              <%= project.has_ratings? ? project.average_servicedesk_rating.to_i : 0  %>
             </td>
             <td class="px-4 py-4 text-left">
               <%= project.user.name %>

--- a/app/views/project/show.html.erb
+++ b/app/views/project/show.html.erb
@@ -39,6 +39,40 @@
           <p class="text-sm font-semibold"><%= @project.start_date.strftime("%d %b %Y") %></p>
         </div>
       </div>
+
+      <div class="grid grid-cols-[auto_1fr_auto] items-center gap-3 sm:gap-4">
+        <div class="flex-shrink-0">
+          <!-- Star icon -->
+          <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="size-6 text-yellow-500">
+            <path d="M12 .587l3.668 7.425L24 9.75l-6 5.85 1.417 8.267L12 19.5l-7.417 4.367L6 15.6 0 9.75l8.332-1.738z"/>
+          </svg>
+        </div>
+        <div class="flex flex-col">
+          <h2 class="text-md font-light">Overall Rating</h2>
+          <% if @project.has_ratings? %>
+            <p class="text-sm font-semibold flex items-center space-x-2">
+              <span><%= @project.average_servicedesk_rating.to_i %> / 5</span>
+              <span class="flex">
+                <% 5.times do |i| %>
+                  <% if i < @project.average_servicedesk_rating.round %>
+                    <!-- filled star -->
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="size-4 text-yellow-500">
+                      <path d="M12 .587l3.668 7.425L24 9.75l-6 5.85 1.417 8.267L12 19.5l-7.417 4.367L6 15.6 0 9.75l8.332-1.738z"/>
+                    </svg>
+                  <% else %>
+                    <!-- empty star -->
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" viewBox="0 0 24 24" class="size-4 text-gray-300">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 17.25l-6.172 3.243 1.179-6.873L2.014 8.757l6.9-1.003L12 1.5l3.086 6.254 6.9 1.003-4.993 4.863 1.179 6.873L12 17.25z" />
+                    </svg>
+                  <% end %>
+                <% end %>
+              </span>
+            </p>
+          <% else %>
+            <p class="text-sm font-semibold text-gray-500">No ratings yet</p>
+          <% end %>
+        </div>
+      </div>
     </div>
     
     <!-- Second Column -->

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -148,6 +148,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.index ["product_id"], name: "index_banking_types_on_product_id"
   end
 
+  create_table "banking_types_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "product_id", null: false
+    t.uuid "banking_type_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id", "banking_type_id"], name: "index_banking_types_products_on_product_and_banking_type", unique: true
+  end
+
   create_table "boards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.uuid "product_id", null: false
@@ -342,7 +350,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.uuid "banking_type_id"
     t.uuid "creator_id"
     t.uuid "product_id"
-    t.string "summary"
+    t.string "summary", null: false
     t.string "defect_unique"
     t.string "issue_type", default: "Bug"
     t.boolean "draft", default: false, null: false
@@ -560,199 +568,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
     t.index ["deleted_on"], name: "index_milestones_on_deleted_on"
     t.index ["product_id"], name: "index_milestones_on_product_id"
     t.index ["status_id"], name: "index_milestones_on_status_id"
-  end
-
-  create_table "motor_alert_locks", force: :cascade do |t|
-    t.bigint "alert_id", null: false
-    t.string "lock_timestamp", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["alert_id", "lock_timestamp"], name: "index_motor_alert_locks_on_alert_id_and_lock_timestamp", unique: true
-    t.index ["alert_id"], name: "index_motor_alert_locks_on_alert_id"
-  end
-
-  create_table "motor_alerts", force: :cascade do |t|
-    t.bigint "query_id", null: false
-    t.string "name", null: false
-    t.text "description"
-    t.text "to_emails", null: false
-    t.boolean "is_enabled", default: true, null: false
-    t.text "preferences", null: false
-    t.bigint "author_id"
-    t.string "author_type"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "motor_alerts_name_unique_index", unique: true, where: "(deleted_at IS NULL)"
-    t.index ["query_id"], name: "index_motor_alerts_on_query_id"
-    t.index ["updated_at"], name: "index_motor_alerts_on_updated_at"
-  end
-
-  create_table "motor_api_configs", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "url", null: false
-    t.text "preferences", null: false
-    t.text "credentials", null: false
-    t.text "description"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "motor_api_configs_name_unique_index", unique: true, where: "(deleted_at IS NULL)"
-  end
-
-  create_table "motor_audits", force: :cascade do |t|
-    t.string "auditable_id"
-    t.string "auditable_type"
-    t.string "associated_id"
-    t.string "associated_type"
-    t.bigint "user_id"
-    t.string "user_type"
-    t.string "username"
-    t.string "action"
-    t.text "audited_changes"
-    t.bigint "version", default: 0
-    t.text "comment"
-    t.string "remote_address"
-    t.string "request_uuid"
-    t.datetime "created_at"
-    t.index ["associated_type", "associated_id"], name: "motor_auditable_associated_index"
-    t.index ["auditable_type", "auditable_id", "version"], name: "motor_auditable_index"
-    t.index ["created_at"], name: "index_motor_audits_on_created_at"
-    t.index ["request_uuid"], name: "index_motor_audits_on_request_uuid"
-    t.index ["user_id", "user_type"], name: "motor_auditable_user_index"
-  end
-
-  create_table "motor_configs", force: :cascade do |t|
-    t.string "key", null: false
-    t.text "value", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_motor_configs_on_key", unique: true
-    t.index ["updated_at"], name: "index_motor_configs_on_updated_at"
-  end
-
-  create_table "motor_dashboards", force: :cascade do |t|
-    t.string "title", null: false
-    t.text "description"
-    t.text "preferences", null: false
-    t.bigint "author_id"
-    t.string "author_type"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["title"], name: "motor_dashboards_title_unique_index", unique: true, where: "(deleted_at IS NULL)"
-    t.index ["updated_at"], name: "index_motor_dashboards_on_updated_at"
-  end
-
-  create_table "motor_forms", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "description"
-    t.text "api_path", null: false
-    t.string "http_method", null: false
-    t.text "preferences", null: false
-    t.bigint "author_id"
-    t.string "author_type"
-    t.datetime "deleted_at"
-    t.string "api_config_name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "motor_forms_name_unique_index", unique: true, where: "(deleted_at IS NULL)"
-    t.index ["updated_at"], name: "index_motor_forms_on_updated_at"
-  end
-
-  create_table "motor_note_tag_tags", force: :cascade do |t|
-    t.bigint "tag_id", null: false
-    t.bigint "note_id", null: false
-    t.index ["note_id", "tag_id"], name: "motor_note_tags_note_id_tag_id_index", unique: true
-    t.index ["tag_id"], name: "index_motor_note_tag_tags_on_tag_id"
-  end
-
-  create_table "motor_note_tags", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "motor_note_tags_name_unique_index", unique: true
-  end
-
-  create_table "motor_notes", force: :cascade do |t|
-    t.text "body"
-    t.bigint "author_id"
-    t.string "author_type"
-    t.string "record_id", null: false
-    t.string "record_type", null: false
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["author_id", "author_type"], name: "motor_notes_author_id_author_type_index"
-    t.index ["record_id", "record_type"], name: "motor_notes_record_id_record_type_index"
-  end
-
-  create_table "motor_notifications", force: :cascade do |t|
-    t.string "title", null: false
-    t.text "description"
-    t.bigint "recipient_id", null: false
-    t.string "recipient_type", null: false
-    t.string "record_id"
-    t.string "record_type"
-    t.string "status", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["recipient_id", "recipient_type"], name: "motor_notifications_recipient_id_recipient_type_index"
-    t.index ["record_id", "record_type"], name: "motor_notifications_record_id_record_type_index"
-  end
-
-  create_table "motor_queries", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "description"
-    t.text "sql_body", null: false
-    t.text "preferences", null: false
-    t.bigint "author_id"
-    t.string "author_type"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "motor_queries_name_unique_index", unique: true, where: "(deleted_at IS NULL)"
-    t.index ["updated_at"], name: "index_motor_queries_on_updated_at"
-  end
-
-  create_table "motor_reminders", force: :cascade do |t|
-    t.bigint "author_id", null: false
-    t.string "author_type", null: false
-    t.bigint "recipient_id", null: false
-    t.string "recipient_type", null: false
-    t.string "record_id"
-    t.string "record_type"
-    t.datetime "scheduled_at", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["author_id", "author_type"], name: "motor_reminders_author_id_author_type_index"
-    t.index ["recipient_id", "recipient_type"], name: "motor_reminders_recipient_id_recipient_type_index"
-    t.index ["record_id", "record_type"], name: "motor_reminders_record_id_record_type_index"
-    t.index ["scheduled_at"], name: "index_motor_reminders_on_scheduled_at"
-  end
-
-  create_table "motor_resources", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "preferences", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_motor_resources_on_name", unique: true
-    t.index ["updated_at"], name: "index_motor_resources_on_updated_at"
-  end
-
-  create_table "motor_taggable_tags", force: :cascade do |t|
-    t.bigint "tag_id", null: false
-    t.bigint "taggable_id", null: false
-    t.string "taggable_type", null: false
-    t.index ["tag_id"], name: "index_motor_taggable_tags_on_tag_id"
-    t.index ["taggable_id", "taggable_type", "tag_id"], name: "motor_polymorphic_association_tag_index", unique: true
-  end
-
-  create_table "motor_tags", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "motor_tags_name_unique_index", unique: true
   end
 
   create_table "notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1245,6 +1060,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
   add_foreign_key "banking_types", "users", column: "created_by_id"
   add_foreign_key "banking_types", "users", column: "deleted_by_id"
   add_foreign_key "banking_types", "users", column: "modified_by_id"
+  add_foreign_key "banking_types_products", "banking_types"
+  add_foreign_key "banking_types_products", "products"
   add_foreign_key "boards", "products"
   add_foreign_key "boards", "users"
   add_foreign_key "clients", "users"
@@ -1289,11 +1106,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_080626) do
   add_foreign_key "messages", "users"
   add_foreign_key "milestones", "products"
   add_foreign_key "milestones", "statuses"
-  add_foreign_key "motor_alert_locks", "motor_alerts", column: "alert_id"
-  add_foreign_key "motor_alerts", "motor_queries", column: "query_id"
-  add_foreign_key "motor_note_tag_tags", "motor_note_tags", column: "tag_id"
-  add_foreign_key "motor_note_tag_tags", "motor_notes", column: "note_id"
-  add_foreign_key "motor_taggable_tags", "motor_tags", column: "tag_id"
   add_foreign_key "notifications", "tickets"
   add_foreign_key "notifications", "users"
   add_foreign_key "products", "clients"


### PR DESCRIPTION
This works on this issue #261 

Users can now see the average rating for a service desk when they go to the service desk show page.