### PR TITLE
Reword properly the service desk ratings

### DIFF
--- a/app/views/project/_project_table.html.erb
+++ b/app/views/project/_project_table.html.erb
@@ -38,7 +38,7 @@
               <%= project.tickets.count %>
             </td>
             <td class="px-4 py-4 text-center">
-              <%= project.has_ratings? ? project.average_servicedesk_rating.to_i : 0  %>
+              <%= project.has_ratings? ? project.average_servicedesk_rating.to_i : "No ratings yet"  %>
             </td>
             <td class="px-4 py-4 text-left">
               <%= project.user.name %>


### PR DESCRIPTION
If a service desk has no ratings, it should show no ratings not 0 as this is not an accurate picture.