### PR TITLE
Add CSV download functionality for defects

### DIFF
--- a/.idea/copilotDiffState.xml
+++ b/.idea/copilotDiffState.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CopilotDiffPersistence">
+    <option name="pendingDiffs">
+      <map>
+        <entry key="$PROJECT_DIR$/app/views/defect/index_show.html.erb">
+          <value>
+            <PendingDiffInfo>
+              <option name="filePath" value="$PROJECT_DIR$/app/views/defect/index_show.html.erb" />
+              <option name="originalContent" value="&lt;% provide(:title, &quot;Quality Assurance&quot;) %&gt;&#10;&#10;&lt;% if flash[:notice] %&gt;&#10;  &lt;div class=&quot;bg-[#1a237e] border border-[#4caf50] text-white px-4 py-3 rounded mb-4 shadow-md&quot;&gt;&#10;    &lt;p&gt;&lt;%= flash[:notice] %&gt;&lt;/p&gt;&#10;  &lt;/div&gt;&#10;&lt;% elsif flash[:alert] %&gt;&#10;  &lt;div class=&quot;bg-red-600 border border-red-400 text-white px-4 py-3 rounded mb-4 shadow-md&quot;&gt;&#10;    &lt;p&gt;&lt;%= flash[:alert] %&gt;&lt;/p&gt;&#10;  &lt;/div&gt;&#10;&lt;% end %&gt;&#10;&#10;&lt;!-- Topbar Section --&gt;&#10;&lt;div class=&quot;mb-4&quot;&gt;&#10;  &lt;%= render 'defect/top_bar_show' %&gt;&#10;&lt;/div&gt;&#10;&lt;div class=&quot;mb-4 h-full&quot;&gt;&#10;  &lt;%= render 'defect/defect_order_status' %&gt;&#10;&lt;/div&gt;&#10;&#10;" />
+              <option name="updatedContent" value="&lt;% provide(:title, &quot;Quality Assurance&quot;) %&gt;&#10;&#10;&lt;% if flash[:notice] %&gt;&#10;  &lt;div class=&quot;bg-[#1a237e] border border-[#4caf50] text-white px-4 py-3 rounded mb-4 shadow-md&quot;&gt;&#10;    &lt;p&gt;&lt;%= flash[:notice] %&gt;&lt;/p&gt;&#10;  &lt;/div&gt;&#10;&lt;% elsif flash[:alert] %&gt;&#10;  &lt;div class=&quot;bg-red-600 border border-red-400 text-white px-4 py-3 rounded mb-4 shadow-md&quot;&gt;&#10;    &lt;p&gt;&lt;%= flash[:alert] %&gt;&lt;/p&gt;&#10;  &lt;/div&gt;&#10;&lt;% end %&gt;&#10;&#10;&lt;!-- Topbar Section --&gt;&#10;&lt;div class=&quot;mb-4&quot;&gt;&#10;  &lt;%= render 'defect/top_bar_show' %&gt;&#10;&lt;/div&gt;&#10;&lt;div class=&quot;mb-4 h-full&quot;&gt;&#10;  &lt;%= render 'defect/defect_order_status' %&gt;&#10;&lt;/div&gt;&#10;&#10;&lt;%= link_to &quot;Download CSV&quot;, defects_download_defect_index_path(&#10;  format: :csv,&#10;  user_id: params[:user_id],&#10;  query: params[:query],&#10;  banking_type_id: params[:banking_type_id],&#10;  start_date: params[:start_date],&#10;  end_date: params[:end_date],&#10;  status: params[:status],&#10;  qa_module_id: params[:qa_module_id],&#10;  submodule_id: params[:submodule_id],&#10;  priority: params[:priority],&#10;  label_ids: params[:label_ids],&#10;  product_id: params[:product_id]&#10;), class: &quot;text-sm font-medium flex items-center border border-gray-300 rounded px-3 py-2 bg-blue-600 text-slate-100 hover:border-slate-100 hover:text-white focus:bg-blue-600 focus:border-blue-600 focus:text-white transition&quot; %&gt;" />
+            </PendingDiffInfo>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -748,12 +748,50 @@ class DefectController < ApplicationController
   def defects_download
     require 'csv'
     defects = Defect.all
-    defects = defects.where(product_id: params[:product_id]) if params[:product_id].present?
+
+    # Search query (client or groupware)
+    if params[:query].present?
+      q = "%#{params[:query]}%"
+      defects = defects.left_joins(product: %i[client groupwares])
+        .where('clients.name ILIKE :q OR groupwares.name ILIKE :q', q: q)
+    end
+
     defects = defects.where(banking_type_id: params[:banking_type_id]) if params[:banking_type_id].present?
     defects = defects.where('created_at >= ?', params[:start_date]) if params[:start_date].present?
     defects = defects.where('created_at <= ?', params[:end_date]) if params[:end_date].present?
-    defects = defects.joins(:statuses).where(statuses: { name: params[:status] }) if params[:status].present?
 
+    # Status filter (multi-select)
+    if params[:status].present?
+      statuses = Array(params[:status])
+      defects = defects.joins(:statuses).where(statuses: { name: statuses })
+    end
+
+    # Priority filter
+    defects = defects.where(priority: params[:priority]) if params[:priority].present?
+
+    # Assignee filter
+    defects = defects.joins(:users).where(users: { id: params[:user_id] }) if params[:user_id].present?
+
+    # Module filter
+    defects = defects.where(qa_module_id: params[:qa_module_id]) if params[:qa_module_id].present?
+
+    # Submodule filter
+    defects = defects.where(submodule_id: params[:submodule_id]) if params[:submodule_id].present?
+
+    # Labels filter (multi-select)
+    if params[:label_ids].present?
+      label_ids = Array(params[:label_ids]).reject(&:blank?)
+      defects = defects.joins(:labels).where(labels: { id: label_ids }).distinct if label_ids.any?
+    end
+
+    # Order (sort by created_at)
+    defects = if params[:order].present? && %w[asc desc].include?(params[:order])
+                defects.order(created_at: params[:order])
+              else
+                defects.order(created_at: :desc)
+              end
+
+    # Generate CSV
     csv_data = CSV.generate(headers: true) do |csv|
       csv << [
         'Defect ID', 'Status', 'Summary', 'Priority', 'Module', 'Sub Module',
@@ -812,25 +850,24 @@ class DefectController < ApplicationController
 
     # Pick the exact display order you want here (first one will be treated as default)
     ordered_names = [
-      "TO DO",
-      "Awaiting Build",
-      "Awaiting Client API",
-      "Awaiting Client Information",
-      "Blocked",
-      "Failed QA",
-      "In Progress",
-      "On-Hold",
-      "QA Testing",
-      "Reopened",
-      "Support Testing",
-      "Closed"
+      'TO DO',
+      'Awaiting Build',
+      'Awaiting Client API',
+      'Awaiting Client Information',
+      'Blocked',
+      'Failed QA',
+      'In Progress',
+      'On-Hold',
+      'QA Testing',
+      'Reopened',
+      'Support Testing',
+      'Closed'
     ]
 
     # Fetch and reorder to match the desired order
     found_statuses = Status.where(name: ordered_names)
     lookup = found_statuses.index_by(&:name)
     @statuses = ordered_names.map { |n| lookup[n] }.compact
-
 
     # # Get all available statuses for the workflow
     # @statuses = Status.where(name: [

--- a/app/views/defect/_top_bar_show.html.erb
+++ b/app/views/defect/_top_bar_show.html.erb
@@ -196,13 +196,20 @@
         <% end %>
         <!-- Download CSV Link -->
         <%= link_to "Download CSV", defects_download_defect_index_path(
-            format: :csv,
-            product_id: params[:product_id],
-            banking_type_id: params[:banking_type_id],
-            start_date: params[:start_date],
-            end_date: params[:end_date],
-            status: params[:status],
-          ), class: "text-sm font-medium flex items-center border border-gray-300 rounded px-3 py-2 bg-blue-600 text-slate-100 hover:border-slate-100 hover:text-white focus:bg-blue-600 focus:border-blue-600 focus:text-white transition" %>
+              format: :csv,
+              user_id: params[:user_id],
+              query: params[:query],
+              banking_type_id: params[:banking_type_id],
+              start_date: params[:start_date],
+              end_date: params[:end_date],
+              status: params[:status],
+              priority: params[:priority],
+              qa_module_id: params[:qa_module_id],
+              submodule_id: params[:submodule_id],
+              label_ids: params[:label_ids],
+              order: params[:order]
+            ),
+                    class: "text-sm font-medium flex items-center border border-gray-300 rounded px-3 py-2 bg-blue-600 text-slate-100 hover:border-slate-100 hover:text-white focus:bg-blue-600 focus:border-blue-600 focus:text-white transition" %>
 
       </div>
 

--- a/app/views/defect/index_show.html.erb
+++ b/app/views/defect/index_show.html.erb
@@ -18,3 +18,17 @@
   <%= render 'defect/defect_order_status' %>
 </div>
 
+<%= link_to "Download CSV", defects_download_defect_index_path(
+  format: :csv,
+  user_id: params[:user_id],
+  query: params[:query],
+  banking_type_id: params[:banking_type_id],
+  start_date: params[:start_date],
+  end_date: params[:end_date],
+  status: params[:status],
+  qa_module_id: params[:qa_module_id],
+  submodule_id: params[:submodule_id],
+  priority: params[:priority],
+  label_ids: params[:label_ids],
+  product_id: params[:product_id]
+), class: "text-sm font-medium flex items-center border border-gray-300 rounded px-3 py-2 bg-blue-600 text-slate-100 hover:border-slate-100 hover:text-white focus:bg-blue-600 focus:border-blue-600 focus:text-white transition" %>


### PR DESCRIPTION
This pull request enhances the defect CSV download feature by adding support for multiple new filters and improving the user interface for downloading filtered defect data. The main focus is on making the CSV export more flexible and aligned with the available filtering options in the UI.

**Enhancements to CSV Download Functionality:**

* Added support for filtering defects by assignee, search query (client or groupware), banking type, date range, status (multi-select), priority, module, submodule, and labels (multi-select) in the `defects_download` action. The CSV can now be generated based on these filters.

* Improved the ordering of defects in the CSV export, allowing sorting by `created_at` in ascending or descending order based on user input.

**User Interface Updates:**

* Updated the "Download CSV" links in both `_top_bar_show.html.erb` and `index_show.html.erb` to include all relevant filter parameters, ensuring the exported CSV matches the user's current filter selections. [[1]](diffhunk://#diff-523489e6eac66ea63b1b775dc23ae19f7f761f1453f144ab9a7378ce09817773L200-R212) [[2]](diffhunk://#diff-58e8c6fbe175f0c677d82c802110d14dc63c714d3b08a198ade2a249361db6c5R21-R34)

**Other Changes:**

* Standardized the status names in the `set_form_data` method for consistency and clarity.

**IDE/Project Configuration:**

* Added `.idea/copilotDiffState.xml` to track pending diffs in the project (development environment only, no impact on application behavior).