### PR TITLE
Devise/resp

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,33 +1,28 @@
 <% provide(:title, "Resend Confirmation Instructions") %>
-
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: {turbo: false}) do |f| %>
-  <section class="mx-auto pr-64 ">
-    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">
-      <div class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
-        <%= image_tag 'logo.png', class: 'w-72 hidden dark:block' %>
-        <%= image_tag 'logo-white-bg.png', class: 'w-72 block dark:hidden' %>
-      </div>
-      <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
-        <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
-          <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-            Resend confirmation instructions
-          </h1>
-          <p class="text-sm font-light">
-            <%= render "devise/shared/error_messages", resource: resource %>
-          </p>
-          <div class="field">
-            <%= f.label :email, class: "block mb-2 text-sm font-medium" %><br />
-            <%= f.email_field :email, autofocus: true, class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", placeholder: 'jay@craftsilicon.com', required: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-          </div>
-          <div class="actions mt-2">
-            <%= f.submit "Resend Instructions", class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full' %>
-          </div>
-          <p class="mt-2 text-sm font-light">
-            <%= render "devise/shared/links" %>
-          </p>
+<div class="min-h-screen flex flex-col md:flex-row bg-gray-50 dark:bg-gray-900">
+  <!-- Left side image/logo (always visible, on top for mobile, left for desktop) -->
+  <div class="flex w-full md:w-1/2 items-center justify-center bg-gray-100 dark:bg-gray-900 min-h-[200px] md:min-h-screen py-8 md:py-0">
+    <div class="flex flex-col items-center w-full px-4">
+      <%= image_tag 'logo.png', class: 'w-24 md:w-32 h-24 md:h-32 object-contain mb-2 md:mb-4 hidden dark:block mx-auto transition-all duration-300' %>
+      <%= image_tag 'logo-white-bg.png', class: 'w-24 md:w-32 h-24 md:h-32 object-contain mb-2 md:mb-4 block dark:hidden mx-auto transition-all duration-300' %>
+      <p class="text-base md:text-lg text-gray-600 dark:text-gray-300 text-center">Email confirmation</p>
+    </div>
+  </div>
+  <!-- Right side form -->
+  <div class="w-full md:w-1/2 flex items-center justify-center bg-white dark:bg-gray-800 min-h-[400px] md:min-h-screen py-8 md:py-0">
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'w-full' }, data: {turbo: false}) do |f| %>
+      <div class="w-full max-w-md mx-auto px-4 sm:px-6">
+        <h1 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-4 sm:mb-6 text-center">Resend confirmation instructions</h1>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="mb-4">
+          <label for="email" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Email</label>
+          <%= f.email_field :email, autofocus: true, class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black", placeholder: 'jay@craftsilicon.com', required: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+        </div>
+        <%= f.submit "Resend Instructions", class: 'h-12 bg-blue-600 hover:bg-blue-700 transition-colors p-3 rounded-lg font-bold text-white w-full mb-4' %>
+        <div class="text-center text-sm text-gray-600 dark:text-gray-300">
+          <%= render "devise/shared/links" %>
         </div>
       </div>
-    </div>
-  </section>
-<% end %>
-
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,32 +1,28 @@
-<% provide(:title, "Forgot Passowrd") %>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: {turbo: false}) do |f| %>
-  <section class="mx-auto pr-64 ">
-      <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">
-        <div class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
-          <%= image_tag 'logo.png', class: 'w-72 hidden dark:block' %>
-          <%= image_tag 'logo-white-bg.png', class: 'w-72 block dark:hidden' %>
+<% provide(:title, "Forgot Password") %>
+<div class="min-h-screen w-full flex flex-col md:flex-row bg-gray-50 dark:bg-gray-900">
+  <!-- Left side image/logo (always visible, on top for mobile, left for desktop) -->
+  <div class="hidden md:flex w-full md:w-1/2 items-center justify-center bg-gray-100 dark:bg-gray-900 min-h-screen">
+    <div class="flex flex-col items-center w-full">
+      <%= image_tag 'logo.png', class: 'w-32 h-32 object-contain mb-4 hidden dark:block mx-auto' %>
+      <%= image_tag 'logo-white-bg.png', class: 'w-32 h-32 object-contain mb-4 block dark:hidden mx-auto' %>
+      <p class="text-lg text-gray-600 dark:text-gray-300 text-center">Reset your password</p>
+    </div>
+  </div>
+  <!-- Right side form -->
+  <div class="w-full md:w-1/2 flex items-center justify-center bg-white dark:bg-gray-800 min-h-screen">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'w-full' }, data: {turbo: false}) do |f| %>
+      <div class="w-full max-w-md mx-auto">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">Forgot Password</h1>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="mb-4">
+          <label for="email" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Email</label>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black", placeholder: 'ab@craftsilicon.com', required: true %>
         </div>
-        <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
-          <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
-            <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-             Forgot Password
-            </h1>
-            <%= render "devise/shared/error_messages", resource: resource %>
-            <div class="space-y-4 md:space-y-6">
-              <div class="field">
-                <%= f.label :email, :email, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white"  %><br />
-                <%= f.email_field :email, autofocus: true, autocomplete: "email", class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", placeholder: 'ab@craftsilicon.com', required: true %>
-              </div>
-              <div class="actions">
-                <%= f.submit "Send me reset password instructions", class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full mt-3' %>
-              </div>
-            </div>
-            <p class="text-sm font-light">
-              <%= render "devise/shared/links" %>
-            </p>
-          </div>
+        <%= f.submit "Send me reset password instructions", class: 'h-12 bg-blue-600 hover:bg-blue-700 transition-colors p-3 rounded-lg font-bold text-white w-full mb-4' %>
+        <div class="text-center text-sm text-gray-600 dark:text-gray-300">
+          <%= render "devise/shared/links" %>
         </div>
       </div>
-  </section>
-<% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,76 +1,74 @@
-
-  <div class="mx-auto">
-    <h2>Update Profile</h2>
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: {turbo: true}) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
-      <div class="mb-5">
-        <label for="email" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-          First Name
-        </label>
-        <% if current_user.has_role?(:admin) %>
-          <%= f.text_field :first_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700", placeholder: 'Jay', required: true %>
-        <% else %>
-          <%= f.text_field :first_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-[#B2B8C2] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700", placeholder: 'Jay', readonly: true %>
-        <% end %>
-      </div>
-      <div class="mb-5">
-        <label for="last name" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-          Last Name
-        </label>
-        <% if current_user.has_role?(:admin) %>
-          <%= f.text_field :last_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700", placeholder: 'Strong', required: true %>
-        <% else %>
-          <%= f.text_field :last_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-[#B2B8C2] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700", placeholder: 'Strong', readonly: true %>
-        <% end %>
-      </div>
-      <div class="mb-5">
-        <label for="email" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-          Your email
-        </label>
-        <% if current_user.has_role?(:admin) %>
-          <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: "h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700", placeholder: 'name@craftsilicon.com', required: true %>
-        <% else %>
-          <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: "h-12 border border-[#B2B8C2] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700", placeholder: 'name@craftsilicon.com', readonly: true %>
-        <% end %>
-      </div>
-      <div class="mb-5">
-        <label for="profile_picture" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-          Profile Picture
-        </label>
-        <%= f.file_field :profile_picture, class: " p-2 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full"  %>
-      </div>
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %>
-        </div>
-      <% end %>
-      <div class="grid-cols-3 grid gap-2">
-        <div class="field">
-          <%= f.label :password %>
-          <i class="block mb-2 text-xs font-medium text-gray-900 dark:text-white ">
-            (leave blank if you don't want to change it)
-          </i><br />
-          <%= f.password_field :password, autocomplete: "new-password", class: " p-2 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700" %>
-          <% if @minimum_password_length %>
-            <br />
-            <em>
-              <%= @minimum_password_length %> characters minimum</em>
+<% provide(:title, "Edit Profile") %>
+<div class="min-h-screen w-full flex flex-col md:flex-row bg-gray-50 dark:bg-gray-900">
+  <!-- Left side image/logo (always visible, on top for mobile, left for desktop) -->
+  <div class="flex w-full md:w-1/2 items-center justify-center bg-gray-100 dark:bg-gray-900 p-8 md:min-h-screen order-2 md:order-1">
+    <div class="flex flex-col items-center w-full">
+      <%= image_tag 'logo.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-4 hidden dark:block mx-auto transition-all duration-300' %>
+      <%= image_tag 'logo-white-bg.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-4 block dark:hidden mx-auto transition-all duration-300' %>
+      <p class="text-base md:text-lg text-gray-600 dark:text-gray-300 text-center">Edit your profile</p>
+    </div>
+  </div>
+  <!-- Right side form -->
+  <div class="w-full md:w-1/2 flex items-center justify-center bg-white dark:bg-gray-800 min-h-screen order-1 md:order-2">
+    <div class="w-full max-w-md md:max-w-lg mx-auto px-4 py-8 md:py-12 rounded-xl shadow-lg bg-white dark:bg-gray-800 transition-all duration-300">
+      <h2 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">Update Profile</h2>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'w-full space-y-4' }, data: {turbo: true}) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div>
+          <label for="first_name" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">First Name</label>
+          <% if current_user.has_role?(:admin) %>
+            <%= f.text_field :first_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700", placeholder: 'Jay', required: true %>
+          <% else %>
+            <%= f.text_field :first_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700", placeholder: 'Jay', readonly: true %>
           <% end %>
         </div>
-        <div class="field">
-          <%= f.label :password_confirmation %>
-          <i class="block mb-2 text-xs font-medium text-gray-900 dark:text-white">
-            (Confirm your password)
-          </i><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: " p-2 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700" %>
+        <div>
+          <label for="last_name" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Last Name</label>
+          <% if current_user.has_role?(:admin) %>
+            <%= f.text_field :last_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700", placeholder: 'Strong', required: true %>
+          <% else %>
+            <%= f.text_field :last_name, autofocus: true, autocomplete: 'name', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700", placeholder: 'Strong', readonly: true %>
+          <% end %>
         </div>
-        <div class="field">
-          <%= f.label :current_password %> <i class="block mb-2 text-xs font-medium text-gray-900 dark:text-white">(we need your current password to confirm your changes)</i><br />
-          <%= f.password_field :current_password, autocomplete: "current-password", class: " p-2 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:bg-gray-700" %>
+        <div>
+          <label for="email" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Your email</label>
+          <% if current_user.has_role?(:admin) %>
+            <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700", placeholder: 'name@craftsilicon.com', required: true %>
+          <% else %>
+            <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700", placeholder: 'name@craftsilicon.com', readonly: true %>
+          <% end %>
         </div>
-      </div>
-      <div class="actions mt-2">
-        <%= f.submit "Update",   class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-1/5'  %>
-      </div>
-    <% end %>
+        <div>
+          <label for="profile_picture" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Profile Picture</label>
+          <%= f.file_field :profile_picture, class: "p-2 border border-gray-300 focus:border-blue-500 rounded-lg w-full bg-white dark:bg-gray-700"  %>
+        </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div class="text-sm text-yellow-700 dark:text-yellow-300">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <%= f.label :password, class: "block mb-1 text-xs font-medium text-gray-700 dark:text-gray-200" %>
+            <span class="block mb-1 text-xs text-gray-500">(leave blank if you don't want to change it)</span>
+            <%= f.password_field :password, autocomplete: "new-password", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700" %>
+            <% if @minimum_password_length %>
+              <span class="block mt-1 text-xs text-gray-500"><%= @minimum_password_length %> characters minimum</span>
+            <% end %>
+          </div>
+          <div>
+            <%= f.label :password_confirmation, class: "block mb-1 text-xs font-medium text-gray-700 dark:text-gray-200" %>
+            <span class="block mb-1 text-xs text-gray-500">(Confirm your password)</span>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700" %>
+          </div>
+          <div>
+            <%= f.label :current_password, class: "block mb-1 text-xs font-medium text-gray-700 dark:text-gray-200" %>
+            <span class="block mb-1 text-xs text-gray-500">(we need your current password to confirm your changes)</span>
+            <%= f.password_field :current_password, autocomplete: "current-password", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:bg-gray-700" %>
+          </div>
+        </div>
+        <div class="actions mt-4">
+          <%= f.submit "Update", class: 'h-12 bg-blue-600 hover:bg-blue-700 transition-colors p-3 rounded-lg font-bold text-white w-full shadow-md'  %>
+        </div>
+      <% end %>
+    </div>
   </div>
-
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,41 +1,40 @@
 <% provide(:title, "Sign Up") %>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <section class="mx-auto pr-64">
-  <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">
-    <a href="#" class="flex items-center mb-6 text-2xl font-semibold">
-      <%= image_tag 'logo.png', class: 'w-72 hidden dark:block' %>
-      <%= image_tag 'logo-white-bg.png', class: 'w-72 block dark:hidden' %>
-    </a>
-    <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
-      <div class="space-y-4 md:space-y-6 sm:p-8">
-        <h1 class="text-xl font-bold leading-tight tracking-tight  md:text-2xl ">
-          Register a CSPM
-        </h1>
+<div class="min-h-screen w-full flex flex-col md:flex-row bg-gray-50 dark:bg-gray-900">
+  <!-- Left side image/logo (always visible, on top for mobile, left for desktop) -->
+  <div class="flex w-full md:w-1/2 items-center justify-center bg-gray-100 dark:bg-gray-900 min-h-[200px] md:min-h-screen py-8 md:py-0">
+    <div class="flex flex-col items-center w-full px-6">
+      <%= image_tag 'logo.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-2 md:mb-4 hidden dark:block mx-auto transition-all duration-300' %>
+      <%= image_tag 'logo-white-bg.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-2 md:mb-4 block dark:hidden mx-auto transition-all duration-300' %>
+      <p class="text-base md:text-lg text-gray-600 dark:text-gray-300 text-center">Join TaskBridgeApp</p>
+    </div>
+  </div>
+  <!-- Right side form -->
+  <div class="w-full md:w-1/2 flex items-center justify-center bg-white dark:bg-gray-800 min-h-[400px] md:min-h-screen py-8 md:py-0">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: 'w-full'}) do |f| %>
+      <div class="w-full max-w-sm sm:max-w-md md:max-w-lg mx-auto px-4 sm:px-8 py-6 rounded-xl shadow-lg bg-white/90 dark:bg-gray-800/90 backdrop-blur-md">
+        <h1 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6 text-center">Create your account</h1>
         <%= render "devise/shared/error_messages", resource: resource %>
-        <div>
-          <label for="email" class="block mb-1 text-sm font-medium">Your email</label>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", required: true %>
+        <div class="mb-4">
+          <label for="email" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Email</label>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black focus:ring-2 focus:ring-blue-200 transition", required: true %>
         </div>
-        <div class="field">
-          <%= f.label :password, class: "block mb-1 text-sm font-medium" %>
-          <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em>
-          <% end %><br />
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: '••••••••', class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", required: true %>
+        <div class="mb-4">
+          <label for="password" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Password
+            <% if @minimum_password_length %>
+              <span class="text-xs text-gray-500">(<%= @minimum_password_length %> characters minimum)</span>
+            <% end %>
+          </label>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: '••••••••', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black focus:ring-2 focus:ring-blue-200 transition", required: true %>
         </div>
-        <div class="field">
-          <%= f.label :password_confirmation, class: "block mb-1 text-sm font-medium " %><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: '••••••••', class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", required: true %>
+        <div class="mb-4">
+          <label for="password_confirmation" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Confirm Password</label>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: '••••••••', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black focus:ring-2 focus:ring-blue-200 transition", required: true %>
         </div>
-        <div class="actions">
-          <%= f.submit "SIGN UP", class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full' %>
-        </div>
-        <p class="mt-2 text-sm font-light">
+        <%= f.submit "Sign up", class: 'h-12 bg-blue-600 hover:bg-blue-700 transition-colors p-3 rounded-lg font-bold text-white w-full mb-4 shadow-md' %>
+        <div class="text-center text-sm text-gray-600 dark:text-gray-300">
           <%= render "devise/shared/links" %>
-        </p>
         </div>
       </div>
+    <% end %>
   </div>
-</section>
-<% end %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,46 +1,43 @@
 <% provide(:title, "Sign In") %>
-<%= form_for(resource, as: resource_name, url: session_path(resource_name),  data: {turbo: false}) do |f| %>
-<section class="mx-auto pr-64 ">
-  <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">
-    <div class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
-      <%= image_tag 'logo.png', class: 'w-72 hidden dark:block' %>
-      <%= image_tag 'logo-white-bg.png', class: 'w-72 block dark:hidden' %>
-    </div>
-    <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
-      <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
-        <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-          Sign in to your account CSPM
-        </h1>
-        <%= render "devise/shared/error_messages", resource: resource %>
-        <div class="space-y-4 md:space-y-6">
-          <div>
-            <label for="email" class="block mb-2 text-sm font-medium">Your email</label>
-            <%= f.email_field :email, autofocus: true, autocomplete: "email",  class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", required: true %>
-          </div>
-          <div>
-            <label for="password" class="block mb-2 text-sm font-medium">Password</label>
-            <%= f.password_field :password, autocomplete: "current-password", placeholder: '••••••••',  class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", required: true%>
-          </div>
-          <div class="flex items-center justify-between">
-            <div class="flex items-start">
-              <div class="flex items-center h-5">
-                <% if devise_mapping.rememberable? %>
-                  <%= f.check_box :remember_me, class: "w-4 h-4 border border-gray-900 rounded bg-gray-50 focus:ring-3 focus:ring-primary-300 dark:bg-gray-700 dark:border-gray-600 dark:focus:ring-primary-600 dark:ring-offset-gray-800" %>
-                <% end %>
-              </div>
-              <div class="ml-3 text-sm">
-                <%= f.label :remember_me %>
-              </div>
-            </div>
-            <div class="text-sm font-medium text-primary-600 hover:underline dark:text-white"><%= render "devise/shared/forgot_password" %></div>
-          </div>
-          <%= f.submit 'LOG IN', class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full'  %>
-          <p class="text-sm font-light">
-           <%= render "devise/shared/links" %>
-          </p>
-        </div>
-      </div>
+<div class="min-h-screen w-full flex flex-col md:flex-row bg-gray-50 dark:bg-gray-900">
+  <!-- Left side image/logo (always visible, on top for mobile, left for desktop) -->
+  <div class="flex w-full md:w-1/2 items-center justify-center bg-gray-100 dark:bg-gray-900 min-h-[200px] md:min-h-screen py-8 md:py-0">
+    <div class="flex flex-col items-center w-full px-6">
+      <%= image_tag 'logo.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-4 hidden dark:block mx-auto transition-all duration-300' %>
+      <%= image_tag 'logo-white-bg.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-4 block dark:hidden mx-auto transition-all duration-300' %>
+      <p class="text-base md:text-lg text-gray-600 dark:text-gray-300 text-center">Welcome to TaskBridgeApp</p>
     </div>
   </div>
-</section>
-<% end %>
+  <!-- Right side form -->
+  <div class="w-full md:w-1/2 flex items-center justify-center bg-white dark:bg-gray-800 min-h-[400px] md:min-h-screen py-8 md:py-0">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), data: {turbo: false}, html: {class: 'w-full'}) do |f| %>
+      <div class="w-full max-w-sm sm:max-w-md mx-auto bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 sm:p-8">
+        <h1 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">Sign in to TaskBridgeApp</h1>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="mb-4">
+          <label for="email" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Email</label>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black", required: true %>
+        </div>
+        <div class="mb-4">
+          <label for="password" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Password</label>
+          <%= f.password_field :password, autocomplete: "current-password", placeholder: '••••••••', class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black", required: true %>
+        </div>
+        <div class="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
+          <div class="flex items-center">
+            <% if devise_mapping.rememberable? %>
+              <%= f.check_box :remember_me, class: "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500" %>
+              <label class="ml-2 text-sm text-gray-700 dark:text-gray-200"><%= f.label :remember_me %></label>
+            <% end %>
+          </div>
+          <div class="text-sm text-right w-full sm:w-auto">
+            <%= render "devise/shared/forgot_password" %>
+          </div>
+        </div>
+        <%= f.submit 'Sign in', class: 'h-12 bg-blue-600 hover:bg-blue-700 transition-colors p-3 rounded-lg font-bold text-white w-full mb-4' %>
+        <div class="text-center text-sm text-gray-600 dark:text-gray-300">
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,13 +1,14 @@
+
 <% if resource.errors.any? %>
-  <div class="p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg dark:bg-red-200 dark:text-red-800" role="alert">
-    <ul class="list-disc pl-5">
+  <div class="p-4 mb-4 text-sm text-red-700 bg-red-100 border border-red-300 rounded-lg dark:bg-red-200 dark:text-red-800 dark:border-red-400" role="alert">
+    <ul class="list-disc pl-5 space-y-1">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>
   </div>
 <% elsif flash[:alert] %>
-  <div class="p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg dark:bg-red-200 dark:text-red-800" role="alert">
+  <div class="p-4 mb-4 text-sm text-red-700 bg-red-100 border border-red-300 rounded-lg dark:bg-red-200 dark:text-red-800 dark:border-red-400" role="alert">
     <%= flash[:alert] %>
   </div>
 <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,22 +1,24 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+<div class="space-y-2">
+  <% if controller_name != 'sessions' %>
+    <%= link_to "Log in", new_session_path(resource_name), class: "block text-blue-600 hover:underline font-medium" %>
   <% end %>
-<% end %>
+
+  <% if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "Sign up", new_registration_path(resource_name), class: "block text-blue-600 hover:underline font-medium" %>
+  <% end %>
+
+  <% if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "block text-blue-600 hover:underline font-medium" %>
+  <% end %>
+
+  <% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "block text-blue-600 hover:underline font-medium" %>
+  <% end %>
+
+  <% if devise_mapping.omniauthable? %>
+    <% resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "w-full bg-gray-100 hover:bg-gray-200 text-gray-800 font-semibold py-2 px-4 rounded transition" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,33 +1,29 @@
 <% provide(:title, "Resend Unlock Instructions") %>
-
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post },data: {turbo: false}) do |f| %>
-  <section class="mx-auto pr-64 ">
-    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">
-      <div class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
-
-        <%= image_tag 'logo.png', class: 'w-72 hidden dark:block' %>
-        <%= image_tag 'logo-white-bg.png', class: 'w-72 block dark:hidden' %>
-      </div>
-      <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
-        <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
-          <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-            Resend unlock instructions
-          </h1>
-          <p class="text-sm font-light">
-            <%= render "devise/shared/error_messages", resource: resource %>
-          </p>
-          <div class="field">
-            <%= f.label :email, :Email, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white"  %><br />
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full dark:text-black", placeholder: 'ab@craftsilicon.com', required: true %>
-          </div>
-          <div class="actions">
-            <%= f.submit "Resend unlock instructions", class: 'capitalize mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full' %>
-          </div>
-          <p class="mt-4 text-sm font-light text-gray-900 dark:text-white">
-            <%= render "devise/shared/links" %>
-          </p>
+<div class="min-h-screen w-full flex flex-col md:flex-row bg-gray-50 dark:bg-gray-900">
+  <!-- Left side image/logo (always visible, on top for mobile, left for desktop) -->
+  <!-- Left side image/logo (top for mobile, left for desktop) -->
+  <div class="w-full md:w-1/2 flex flex-col md:justify-center items-center bg-gray-100 dark:bg-gray-900 min-h-[200px] md:min-h-screen py-8 md:py-0 order-1 md:order-none">
+    <div class="flex flex-col items-center w-full px-4">
+      <%= image_tag 'logo.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-4 hidden dark:block mx-auto transition-all duration-300' %>
+      <%= image_tag 'logo-white-bg.png', class: 'w-24 h-24 md:w-32 md:h-32 object-contain mb-4 block dark:hidden mx-auto transition-all duration-300' %>
+      <p class="text-base md:text-lg text-gray-600 dark:text-gray-300 text-center">Unlock your account</p>
+    </div>
+  </div>
+  <!-- Right side form -->
+  <div class="w-full md:w-1/2 flex items-center justify-center bg-white dark:bg-gray-800 min-h-[400px] md:min-h-screen py-8 md:py-0 order-2 md:order-none">
+    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, class: 'w-full' }, data: {turbo: false}) do |f| %>
+      <div class="w-full max-w-sm sm:max-w-md mx-auto bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 sm:p-8">
+        <h1 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">Resend unlock instructions</h1>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="mb-4">
+          <label for="email" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">Email</label>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "h-12 border border-gray-300 focus:border-blue-500 rounded-lg w-full px-3 dark:text-black", placeholder: 'ab@craftsilicon.com', required: true %>
+        </div>
+        <%= f.submit "Resend unlock instructions", class: 'capitalize h-12 bg-blue-600 hover:bg-blue-700 transition-colors p-3 rounded-lg font-bold text-white w-full mb-4' %>
+        <div class="text-center text-sm text-gray-600 dark:text-gray-300">
+          <%= render "devise/shared/links" %>
         </div>
       </div>
-    </div>
-  </section>
-<% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
   <% else %>
     <main class="mx-auto bg-slate-100 dark:bg-gray-900 text-gray-900 dark:text-slate-100">
       <%= render 'layouts/sidebar' %>
-      <div class="p-8">
+      <div>
         <%= render 'layouts/topbar' %>
         <%= yield %>
       </div>


### PR DESCRIPTION
This pull request updates the UI for all main Devise authentication views (`sign up`, `edit profile`, `forgot password`, and `resend confirmation`) to use a modern, responsive two-column layout with improved styling and accessibility. The changes unify the look and feel across authentication pages, enhance mobile responsiveness, and provide a cleaner, more user-friendly experience.

**Authentication view redesign and improvements:**

* All main Devise views (`new.html.erb` for registrations, confirmations, passwords, and `edit.html.erb` for registrations) now use a responsive two-column layout with the logo and contextual message on the left and the form on the right. This improves consistency and visual appeal across authentication pages. [[1]](diffhunk://#diff-744d99555c831425cf5883c199055bc537850fbdd075776c69dbad920497bb1fL2-R40) [[2]](diffhunk://#diff-4d201ae5c67e8b121860359f6c67d044f5bf68c3d7a4687ca64089bfe5677a13L1-R74) [[3]](diffhunk://#diff-2d0ac465f8102af1bab30cd05e3ac950cd6b9880b376a0338a3e70c02b9d820dL1-R28) F8546d4cL1)
* Form fields have been restyled for better accessibility and clarity, including improved focus states, clearer labels, and consistent spacing. [[1]](diffhunk://#diff-744d99555c831425cf5883c199055bc537850fbdd075776c69dbad920497bb1fL2-R40) [[2]](diffhunk://#diff-4d201ae5c67e8b121860359f6c67d044f5bf68c3d7a4687ca64089bfe5677a13L1-R74) [[3]](diffhunk://#diff-2d0ac465f8102af1bab30cd05e3ac950cd6b9880b376a0338a3e70c02b9d820dL1-R28) F8546d4cL1)

**Specific enhancements per view:**

* **Sign Up:** The registration view now features a welcoming message, clearer password requirements, and a visually distinct form container.
* **Edit Profile:** The profile editing form is modernized, with role-based field editability, improved password change fields, and a more prominent confirmation status message.
* **Forgot Password & Resend Confirmation:** Both views now have clear sectioning, improved error display, and more prominent action buttons, making the recovery process easier for users. ([app/views/devise/passwords/new.html.erbL1-R28](diffhunk://#diff-2d0ac465f8102af1bab30cd05e3ac950cd6b9880b376a0338a3e70c02b9d820dL1-R28), F8546d4cL1)