### PR TITLE
Tickets send to all

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -416,6 +416,19 @@ class TicketsController < ApplicationController
       )
     end
 
+    # Send status update emails
+    if status.name != 'Reopened'
+      @ticket.users.each do |ticket_user|
+        UserMailer.status_update_email(ticket_user, @ticket, current_user, @project).deliver_later
+      end
+    end
+
+    if status.name == 'Reopened'
+      @project.users.each do |project_user|
+        UserMailer.status_update_email(project_user, @ticket, current_user, @project).deliver_later
+      end
+    end
+
     # Emails + logs...
     log_event(@ticket, current_user, 'status_change', "Status was changed to #{status.name}")
     activity('user_activity')

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -65,11 +65,8 @@ class UserMailer < ApplicationMailer
     @current_user = current_user
     @project = project
     @url = project_ticket_url(@ticket.project, @ticket)
-    mail(
-      to: @user.email,
-      bcc: @ticket.user&.email,
-      subject: "Status update for Ticket ID #{@ticket.unique_id}."
-    )
+    mail(to: [@user.email, @ticket.user&.email].uniq.compact, subject: "Ticket assigned with Ticket ID #{@ticket.unique_id}.")
+
   end
 
   # From Product Controller

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -65,7 +65,7 @@ class UserMailer < ApplicationMailer
     @current_user = current_user
     @project = project
     @url = project_ticket_url(@ticket.project, @ticket)
-    mail(to: @user.email, subject: "Status update for Ticket ID #{@ticket.unique_id}.")
+    mail(to: [@user.email, @ticket.user&.email].uniq.compact, subject: "Status update for Ticket ID #{@ticket.unique_id}.")
   end
 
   # From Product Controller

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -65,7 +65,11 @@ class UserMailer < ApplicationMailer
     @current_user = current_user
     @project = project
     @url = project_ticket_url(@ticket.project, @ticket)
-    mail(to: [@user.email, @ticket.user&.email].uniq.compact, subject: "Status update for Ticket ID #{@ticket.unique_id}.")
+    mail(
+      to: @user.email,
+      bcc: @ticket.user&.email,
+      subject: "Status update for Ticket ID #{@ticket.unique_id}."
+    )
   end
 
   # From Product Controller

--- a/app/views/user_mailer/status_update_email.html.erb
+++ b/app/views/user_mailer/status_update_email.html.erb
@@ -17,7 +17,7 @@
 
 <p><strong>Ticket Details:</strong></p>
 <ul>
-  <li><strong>Service Desk Name:</strong> <span class="capitalize"><%= @project.title %></span></li>
+  <li><strong>Service Desk Name:</strong> <span class="capitalize"><%= @ticket.project.title %></span></li>
   <li><strong>Ticket ID:</strong> <%= @ticket.unique_id %></li>
   <li><strong>Subject:</strong> <%= @ticket.subject %></li>
   <li><strong>Ticket Type:</strong> <%= @ticket.issue %></li>


### PR DESCRIPTION
This pull request updates the ticket status notification system to improve how status update emails are sent and displayed. The changes ensure that relevant users are notified appropriately and that email content is accurate.

**Email notification logic:**

* Updated `add_status` in `tickets_controller.rb` to send status update emails to ticket users for most status changes, and to all project users when a ticket is reopened.

**Email delivery and content:**

* Modified `status_update_email` in `user_mailer.rb` to include the ticket's user as a BCC recipient, ensuring they receive status updates even if not the direct recipient.
* Fixed the service desk name in the email template to reference the ticket's project title for accuracy.