### PR TITLE
Enhance profiles to include terminal state timestamps and format tota…

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -113,10 +113,14 @@ class ProfilesController < ApplicationController
 
         assignments_for_user.each do |assign_event|
           assigned_at = assign_event.created_at
-          # Earliest of the next assignment (anyone) or next handover involving selected user
+          # Earliest of the next assignment (anyone), next handover involving selected user,
+          # or when the ticket entered a terminal state (Resolved/Closed/Declined)
           next_assignment = assignments.find { |a| a.created_at > assign_event.created_at }
           next_handover = handovers_for_user.find { |h| h.created_at > assign_event.created_at }
-          candidate_end_times = [next_assignment&.created_at, next_handover&.created_at].compact
+          terminal_time = terminal_state_time_for(ticket)
+          candidate_end_times = [next_assignment&.created_at, next_handover&.created_at, terminal_time]
+                                  .compact
+                                  .select { |t| t > assigned_at }
           end_time = candidate_end_times.min || Time.current
           hold_periods << (end_time - assigned_at)
         end
@@ -132,7 +136,21 @@ class ProfilesController < ApplicationController
     end
   end
 
-  helper_method :parse_assignment_details, :assigned_at_for, :resolved_at_for, :resolution_duration_for
+  helper_method :parse_assignment_details, :assigned_at_for, :resolved_at_for, :resolution_duration_for, :format_full_duration
+
+  # Formats total seconds as a human string with years, months, days, hours, minutes, and seconds
+  def format_full_duration(total_seconds)
+    seconds = total_seconds.to_i
+    return '0 seconds' if seconds <= 0
+
+    parts = ActiveSupport::Duration.build(seconds).parts # e.g., {years:, months:, days:, hours:, minutes:, seconds:}
+    order = [:years, :months, :days, :hours, :minutes, :seconds]
+
+    order.map do |key|
+      value = parts[key].to_i
+      value.positive? ? "#{value} #{key.to_s.singularize}#{'s' if value != 1}" : nil
+    end.compact.join(' ')
+  end
 
   def profiles_show_user
     if params[:user_id] && params[:client_name]
@@ -246,5 +264,35 @@ class ProfilesController < ApplicationController
         end
       end
     end
+  end
+
+  # Returns the earliest timestamp when the ticket enters a terminal state
+  # Terminal states considered: Resolved, Closed, Declined
+  def terminal_state_time_for(ticket)
+    return nil unless ticket
+
+    # Prefer any explicit resolved/closed timestamps on the ticket first
+    times = []
+    times << ticket.resolved_at if ticket.respond_to?(:resolved_at) && ticket.resolved_at.present?
+    times << ticket.closed_at if ticket.respond_to?(:closed_at) && ticket.closed_at.present?
+
+    # Also look into events for resolved/closed/declined
+    events = @all_ticket_events_by_ticket&.[](ticket.id) || []
+    events.sort_by!(&:created_at)
+
+    events.each do |e|
+      d = e.details.to_s.downcase
+      if d.include?('resolved') && (d.include?('status') || d.include?('status changed') || d.include?('changed status') || d.include?('to resolved'))
+        times << e.created_at
+      end
+      if d.include?('closed') && (d.include?('status') || d.include?('status changed') || d.include?('changed status') || d.include?('to closed'))
+        times << e.created_at
+      end
+      if d.include?('declined') && (d.include?('status') || d.include?('status changed') || d.include?('changed status') || d.include?('to declined'))
+        times << e.created_at
+      end
+    end
+
+    times.compact.min
   end
 end

--- a/app/views/profiles/profiles_show.html.erb
+++ b/app/views/profiles/profiles_show.html.erb
@@ -163,8 +163,11 @@
                 </ul>
                 <% total_seconds = @ticket_hold_time_total_seconds[ticket.id].to_i %>
                 <% if total_seconds > 0 %>
+                  <div class="mt-1 text-sm">
+                    <%= "Total Periods: #{hold_periods.size}" %>
+                  </div>
                   <div class="mt-1 font-semibold">
-                    <%= "Total: #{distance_of_time_in_words(Time.at(0), Time.at(total_seconds), include_seconds: true)}" %>
+                    <%= "Total: #{format_full_duration(total_seconds)}" %>
                   </div>
                 <% end %>
               <% else %>


### PR DESCRIPTION
…l duration for improved reporting
This pull request enhances how ticket assignment hold periods are calculated and displayed in the profiles view. The most important changes include more accurate determination of assignment end times by considering terminal ticket states, introduction of a helper to format durations in a human-readable way, and improvements to the user interface to show these details.

### Assignment period calculation improvements
* Assignment end times now consider when a ticket enters a terminal state (Resolved/Closed/Declined), not just the next assignment or handover, for more accurate hold period computation. (`profiles_show` in `app/controllers/profiles_controller.rb`)
* Added a new method `terminal_state_time_for` to find the earliest timestamp when a ticket enters a terminal state, using both ticket attributes and event history. (`app/controllers/profiles_controller.rb`)

### Duration formatting and UI improvements
* Introduced `format_full_duration`, a helper that formats durations in years, months, days, hours, minutes, and seconds for clearer display. (`app/controllers/profiles_controller.rb`)
* Updated the profiles view to use `format_full_duration` for total hold time, and added a display for the number of hold periods per ticket. (`app/views/profiles/profiles_show.html.erb`)