### PR TITLE
Enhance profiles to include terminal state timestamps and format tota…

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -84,6 +84,7 @@ class TasksController < ApplicationController
       @task.users << user
       assigned_user = user # Sending to all users added to the product
       UserMailer.task_assignment_email(user, @task, current_user, assigned_user).deliver_later
+
       activity('user_activity')
         .caused_by(current_user)
         .performed_on(@task)

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -16,7 +16,7 @@ module ProfilesHelper
 
     units.each do |name, secs|
       count = remaining / secs
-      if count > 0
+      if count.positive?
         parts << "#{count} #{name}#{'s' if count > 1}"
         remaining -= count * secs
       end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,2 +1,27 @@
 module ProfilesHelper
+  def format_full_duration_human(total_seconds)
+    return 'less than a minute' if total_seconds < 60
+
+    units = [
+      [:year, 31_536_000],
+      [:month, 2_592_000],
+      [:week, 604_800],
+      [:day, 86_400],
+      [:hour, 3_600],
+      [:minute, 60]
+    ]
+
+    remaining = total_seconds.to_i
+    parts = []
+
+    units.each do |name, secs|
+      count = remaining / secs
+      if count > 0
+        parts << "#{count} #{name}#{'s' if count > 1}"
+        remaining -= count * secs
+      end
+    end
+
+    parts.join(', ')
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -90,9 +90,6 @@ class UserMailer < ApplicationMailer
       format.html { render 'task_assignment_email' }
       format.text { render plain: "You have been assigned to task ##{@task.unique_task_id} - #{@task.name}. View: #{@url}" }
     end
-  end
-
-  def add_state_email(user, task, current_user)
     @user = user
     @task = task
     @current_user = current_user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -46,6 +46,16 @@ class UserMailer < ApplicationMailer
     mail(to: @assigned_user.email, subject: "A ticket with Ticket ID #{@ticket.unique_id} has been edited.")
   end
 
+  def new_message_email(message_user, message, current_user)
+    @message_user = message_user
+    @message = message
+    @current_user = current_user
+    @task = @message.task
+    @product = @task.product
+    @url = product_task_url(@product, @task)
+    mail(to: @message_user.email, subject: 'New Message on Task')
+  end
+
   # From Ticket Controller create
   def ticket_assignment_email(user, project, ticket, current_user, assigned_user)
     @user = user
@@ -85,7 +95,8 @@ class UserMailer < ApplicationMailer
     @task = task
     @current_user = current_user
     @assigned_user = assigned_user
-    @url = product_task_url(@task.product, @task)
+    @product = @task.product
+    @url = product_task_url(@product, @task)
     mail(to: @user.email, subject: 'You have been assigned to a new task')
   end
 
@@ -105,15 +116,6 @@ class UserMailer < ApplicationMailer
     @ticket = ticket
     @url = project_ticket_url(@comment.ticket.project, @comment.ticket)
     mail(to: @user.email, subject: "Root Cause Analysis for Ticket ID #{@comment.ticket.unique_id}.")
-  end
-
-  def bug_mailer_email(user, bug, current_user, assigned_user)
-    @user = user
-    @bug = bug
-    @current_user = current_user
-    @assigned_user = assigned_user
-    @url = product_bug_url(@bug.product, @bug)
-    mail(to: @user.email, subject: 'Bug Assignment')
   end
 
   def issue_created_email(user, issue, project, ticket, current_user)
@@ -203,14 +205,6 @@ class UserMailer < ApplicationMailer
       format.html { render 'finance_sales_email' }
       format.text { render plain: subject_text }
     end
-  end
-
-  def new_message_email(message_user, message, current_user)
-    @message_user = message_user
-    @message = message
-    @current_user = current_user
-    @url = product_tasks_path(@product, @tasks)
-    mail(to: @user.email, subject: 'New Message on Task')
   end
 
   def milestone_payment_toggled(product, milestone, current_user, assigned_user)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -86,10 +86,10 @@ class UserMailer < ApplicationMailer
     @current_user = current_user
     @assigned_user = assigned_user
     @url = product_task_url(@task.product, @task)
-    mail(to: @user.email, subject: 'You have been assigned to a new task') do |format|
-      format.html { render 'task_assignment_email' }
-      format.text { render plain: "You have been assigned to task ##{@task.unique_task_id} - #{@task.name}. View: #{@url}" }
-    end
+    mail(to: @user.email, subject: 'You have been assigned to a new task')
+  end
+
+  def add_state_email(user, task, current_user)
     @user = user
     @task = task
     @current_user = current_user

--- a/app/views/profiles/profiles_show.html.erb
+++ b/app/views/profiles/profiles_show.html.erb
@@ -161,13 +161,13 @@
                     </li>
                   <% end %>
                 </ul>
-                <% total_seconds = @ticket_hold_time_total_seconds[ticket.id].to_i %>
+                <% total_seconds = hold_periods.sum.to_i %>
                 <% if total_seconds > 0 %>
                   <div class="mt-1 text-sm">
                     <%= "Total Periods: #{hold_periods.size}" %>
                   </div>
                   <div class="mt-1 font-semibold">
-                    <%= "Total: #{format_full_duration(total_seconds)}" %>
+                    <%= "Total: #{format_full_duration_human(total_seconds)}" %>
                   </div>
                 <% end %>
               <% else %>

--- a/app/views/tasks/_top_task_bar.html.erb
+++ b/app/views/tasks/_top_task_bar.html.erb
@@ -10,12 +10,16 @@
       <div class="flex flex-row gap-4">
         <h1 class="text-lg sm:text-xl md:text-2xl font-semibold">
           <%= link_to @product.client.name, product_path(@product.id) %> / <span class="text-md font-light"> <%= render partial: 'tasks/priority', locals: { task: @task } %> </span>
-          <span class="text-sm"> from <%= @task.start_date.strftime('%d-%m-%Y') %> to <%= @task.start_date.strftime('%d-%m-%Y') %> </span> /
+          <span class="text-sm"> from <%= @task.start_date.strftime('%d %b %Y') %> to <%= @task.end_date.strftime('%d %b %Y') %> </span> /
           <% if @task.prerequisite_task.present? %>
             <span class="text-sm">Prerequisite Task:
               <%= link_to @task.prerequisite_task.name, product_task_path(@product, @task.prerequisite_task) %>
             </span>
           <% end %>
+          <span class="text-sm">
+            <%= @task.unique_task_id %>
+          </span>
+
         </h1>
         <p class="text-xs sm:text-sm md:text-base">
           <span class="font-medium">

--- a/app/views/user_mailer/new_message_email.html.erb
+++ b/app/views/user_mailer/new_message_email.html.erb
@@ -4,10 +4,10 @@
   <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
 </head>
 <body>
-<h1>Hello, <%= @message_user.first_name %></h1>
+<h1>Hello, <%= @message_user.first_name %> <%= @message_user.last_name %> </h1>
 
 <ul>
-  <li><strong>Messgae:</strong> <%= @message.content.to_plain_text.truncate(3000) %></li>
+  <li><strong>Message:</strong> <%= @message.content.to_plain_text.truncate(3000) %></li>
 </ul>
 
 <p>Click <a href="<%= @url %>">here</a> to view the comment.</p>

--- a/app/views/user_mailer/task_assignment_email.html.erb
+++ b/app/views/user_mailer/task_assignment_email.html.erb
@@ -4,6 +4,7 @@
   <%= @assigned_user.first_name %> <%= @assigned_user.last_name %>
   have been assigned to the Task: <%= @task.name %> of topic: <%= @task.priority %>
   by <%= @current_user.name %> </p>
+
 <p>Click <a href="<%= @url %>">here</a> to view the ticket.</p>
 
 <p>Best regards,</p>

--- a/app/views/user_mailer/task_assignment_email.text.erb
+++ b/app/views/user_mailer/task_assignment_email.text.erb
@@ -1,9 +1,0 @@
-Hello <%= @user.first_name %> <%= @user.last_name %>,
-
-You have been assigned to task <%= @task.unique_task_id %> - <%= @task.name %> (priority: <%= @task.priority %>) by <%= @current_user.name %>.
-
-View the task: <%= @url %>
-
-Best regards,
-Your Team
-


### PR DESCRIPTION
…l duration for improved reporting
This pull request introduces a new helper method to improve the formatting of ticket hold times in the profiles view. The main change is the addition of a more detailed, human-readable duration format for displaying total hold periods.

### Enhancements to duration formatting in profiles:

* Added the `format_full_duration_human` method to `ProfilesHelper`, which converts a total number of seconds into a readable format including years, months, weeks, days, hours, and minutes.
* Updated the profiles view (`profiles_show.html.erb`) to use the new `format_full_duration_human` method for displaying total hold times, providing clearer information to users.

### Minor code cleanup:

* Removed unused code from `UserMailer`, specifically the stub for `add_state_email`, improving code clarity.