### PR TITLE
Defects indexshow filterproperly

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -73,10 +73,16 @@ class DefectController < ApplicationController
     @defects = Defect.published
       .includes(:users, :qa_module, :labels, :banking_type, :statuses, product: %i[client groupwares])
 
-    # Client filter (exact, case-insensitive)
-    if params[:client_name].present?
+    # Client filter (exact, case-insensitive, and scoped by product_id)
+    if params[:client_name].present? && params[:product_id].present?
       @defects = @defects.joins(product: :client)
         .where('LOWER(clients.name) = ?', params[:client_name].to_s.downcase.strip)
+        .where(products: { id: params[:product_id] })
+    elsif params[:client_name].present?
+      @defects = @defects.joins(product: :client)
+        .where('LOWER(clients.name) = ?', params[:client_name].to_s.downcase.strip)
+    elsif params[:product_id].present?
+      @defects = @defects.where(product_id: params[:product_id])
     end
 
     # Status filter (multiple checkboxes -> status[])

--- a/app/views/banking_types/index.html.erb
+++ b/app/views/banking_types/index.html.erb
@@ -50,8 +50,6 @@
       <p class="text-gray-600 dark:text-gray-300 mb-4">
         No banking types found.
       </p>
-      <%= link_to "Add First Banking Type", new_banking_type_path,
-                  class: "px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded text-sm" %>
     </div>
   <% end %>
 </div>

--- a/app/views/defect/new.html.erb
+++ b/app/views/defect/new.html.erb
@@ -57,6 +57,7 @@
                         focus:outline-none focus:ring-2 focus:ring-blue-500
                         dark:bg-gray-700 dark:text-white dark:border-gray-600"
                 required
+                disabled
           />
 
           <!-- Hidden product_id field -->


### PR DESCRIPTION
Filter to show the defects of a client and the product_id only
Ensure that the banking type does not break when you do not have any banking types
Disable the projects dropdown to prevent a user from selecting another project accidentally as everything else is preloaded for the user