### PR TITLE
Add permissionsfor the defect

### DIFF
--- a/app/controllers/defect_controller.rb
+++ b/app/controllers/defect_controller.rb
@@ -826,7 +826,7 @@ class DefectController < ApplicationController
       end
     end
 
-    send_data csv_data, filename: "defects_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.csv", type: 'text/csv'
+    send_data csv_data, filename: "defects_#{Time.zone.now.strftime('%Y-%m-%d %H:%M')}.csv", type: 'text/csv'
   end
 
   def defects_download_excel

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -56,9 +56,9 @@ class Ability
       can %i[edit update], Ticket, user_id: user.id
       can :manage, Issue, user_id: user.id
       can :update_due_date, Ticket
-      cannot %i[create delete edit download_tasks_csv], Product
+      cannot %i[create delete edit], Product
       cannot %i[create delete edit], Board
-      can :read, Product
+      can %i[read download_tasks_csv], Product
       can :read, Board
       can :read, Task
       can :manage, Message
@@ -81,7 +81,8 @@ class Ability
       can %i[profiles_show profiles_show_user], :profiles
 
     elsif user.has_role? :qa
-      can %i[create edit update destroy], DefectMessage, user_id: user.id
+      can :manage, DefectMessage, user_id: user.id
+      can %i[manage defects_download defects_download_excel], Defect
 
     else
       can :read, Project


### PR DESCRIPTION
This pull request updates user permissions and improves the naming convention for defect CSV downloads. The main changes involve expanding access for certain actions on `Product` and `Defect` models, especially for QA users, and updating the CSV filename format for defect downloads.

**Permissions updates:**

* Allowed users to download tasks CSV for `Product` by adding `download_tasks_csv` to permitted actions, and removed this action from the list of forbidden actions.
* For QA users, granted full management permissions on `DefectMessage` and allowed management and download actions (`defects_download`, `defects_download_excel`) on `Defect`.

**Defect CSV download improvement:**

* Changed the filename format for defect CSV downloads to use the `YYYY-MM-DD_HH:MM` pattern for better readability and consistency.