### PR TITLE
Support desk user management realign

### DIFF
--- a/app/views/project/_assign_people.html.erb
+++ b/app/views/project/_assign_people.html.erb
@@ -1,38 +1,6 @@
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
   <% if current_user.has_role?(:admin) || current_user.has_role?('project manager') || current_user.has_role?(:agent) %>
     
-    <!-- Craft Silicon Staff -->
-    <div data-controller="expandable-list">
-      <h3 class="text-sm font-semibold mb-2">Craft Silicon Staff</h3>
-      <div class="text-sm">
-        <!-- Initial visible users -->
-        <div data-expandable-list-target="initialList">
-          <%= @craft_silicon_users.first(5).map(&:name).join(", ") %>
-        </div>
-        
-        <!-- Full list (hidden by default) -->
-        <div class="hidden mt-2" data-expandable-list-target="fullList">
-          <%= @craft_silicon_users.map(&:name).join(", ") %>
-        </div>
-        
-        <!-- Toggle button (only shows if more than 5 users) -->
-        <% if @craft_silicon_users.count > 5 %>
-          <button class="mt-1 flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300" 
-                  data-action="expandable-list#toggle">
-            <span class="mr-1 text-sm">
-              <span data-expandable-list-target="showText">Show all</span>
-              <span class="hidden" data-expandable-list-target="hideText">Hide</span>
-            </span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform duration-200" 
-                 viewBox="0 0 20 20" fill="currentColor"
-                 data-expandable-list-target="icon">
-              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-          </button>
-        <% end %>
-      </div>
-    </div>
-
     <!-- Clients -->
     <div data-controller="expandable-list">
       <h3 class="text-sm font-semibold mb-2">Clients</h3>
@@ -49,6 +17,38 @@
         
         <!-- Toggle button (only shows if more than 5 users) -->
         <% if @non_craft_silicon_users.count > 5 %>
+          <button class="mt-1 flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300" 
+                  data-action="expandable-list#toggle">
+            <span class="mr-1 text-sm">
+              <span data-expandable-list-target="showText">Show all</span>
+              <span class="hidden" data-expandable-list-target="hideText">Hide</span>
+            </span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform duration-200" 
+                 viewBox="0 0 20 20" fill="currentColor"
+                 data-expandable-list-target="icon">
+              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        <% end %>
+      </div>
+    </div>
+
+        <!-- Craft Silicon Staff -->
+    <div data-controller="expandable-list">
+      <h3 class="text-sm font-semibold mb-2">Craft Silicon Staff</h3>
+      <div class="text-sm">
+        <!-- Initial visible users -->
+        <div data-expandable-list-target="initialList">
+          <%= @craft_silicon_users.first(5).map(&:name).join(", ") %>
+        </div>
+        
+        <!-- Full list (hidden by default) -->
+        <div class="hidden mt-2" data-expandable-list-target="fullList">
+          <%= @craft_silicon_users.map(&:name).join(", ") %>
+        </div>
+        
+        <!-- Toggle button (only shows if more than 5 users) -->
+        <% if @craft_silicon_users.count > 5 %>
           <button class="mt-1 flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300" 
                   data-action="expandable-list#toggle">
             <span class="mr-1 text-sm">

--- a/app/views/project/manage_users.html.erb
+++ b/app/views/project/manage_users.html.erb
@@ -5,7 +5,7 @@
       <!-- Header -->
       <div class="sticky top-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-600 px-6 py-4 rounded-t-xl flex items-center justify-between">
         <div>
-          <h2 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">Manage Project Users</h2>
+          <h2 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">Manage Users</h2>
           <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">Assign people and teams to this support desk</p>
         </div>
         


### PR DESCRIPTION
This pull request updates the user assignment interface in the project views to clarify the distinction between "Clients" and "Craft Silicon Staff" and improves the header for managing users. The main changes involve swapping the order and labeling of user groups in the assignment partial, as well as a minor header text update.

**User assignment interface improvements:**

* Swapped the display order of user groups in `app/views/project/_assign_people.html.erb`, now showing "Clients" first and "Craft Silicon Staff" second. The corresponding variables were updated to match the labels, ensuring that `@non_craft_silicon_users` are shown under "Clients" and `@craft_silicon_users` under "Craft Silicon Staff". [[1]](diffhunk://#diff-c46895eed9b550a7d39e4a66d8fdb76e5ea361dff06ef3a43e6619f7e8eb8148L4-R19) [[2]](diffhunk://#diff-c46895eed9b550a7d39e4a66d8fdb76e5ea361dff06ef3a43e6619f7e8eb8148L36-R51)

**Header update:**

* Changed the header text in `app/views/project/manage_users.html.erb` from "Manage Project Users" to "Manage Users" for clarity and consistency.