### PR TITLE
Update SLA section to display total open tickets instead

### DIFF
--- a/app/views/project/show.html.erb
+++ b/app/views/project/show.html.erb
@@ -123,21 +123,21 @@
               class: "ml-4 px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium rounded transition-colors" %>
         </div>
 
-        <!-- SLA on Target Response -->
+        <!-- All Open Tickets -->
         <div class="flex items-center border border-gray-200 dark:border-gray-300 rounded-lg p-2 bg-transparent">
           <div class="flex-1">
             <div class="flex items-center space-x-2 mb-1">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-gray-500">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2m6 4a9 9 0 11-18 0 9 9 0 0118 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 0 1 0 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 0 1 0-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375Z" />
               </svg>
-              <h3 class="text-sm font-medium text-gray-900 dark:text-white">SLA on Target Response</h3>
+              <h3 class="text-sm font-medium text-gray-900 dark:text-white">All Open Tickets</h3>
             </div>
             <p class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-1">
-              <%= @sla_on_target || 0 %>
+              <%= @total_tickets_open %>
             </p>
           </div>
           <%= link_to "View",
-              project_path(@project, filter: 'sla'),
+              project_path(@project, filter: 'Open'),
               class: "ml-4 px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium rounded transition-colors" %>
         </div>
       </div>


### PR DESCRIPTION
This pull request updates the project overview UI to display the total number of open tickets instead of the SLA on target response. The label, icon, value, and filter link have all been changed to reflect this new focus.

UI changes to ticket statistics:

* Changed the label from "SLA on Target Response" to "All Open Tickets" in `app/views/project/show.html.erb`.
* Updated the icon SVG to better represent open tickets rather than SLA.
* Replaced the displayed value from `@sla_on_target` to `@total_tickets_open`.
* Modified the filter link to use `filter: 'Open'` instead of `filter: 'sla'`.