### PR TITLE
Add open_tasks association to product model and update task count dis…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,6 +162,10 @@ class User < ApplicationRecord
     tickets.joins(:statuses).where.not(statuses: { name: %w[Closed Resolved Declined Approved] }).distinct.count(:id)
   end
 
+  def all_open_tasks_for_the_current_user_count
+    tasks.joins(:statuses).where.not(statuses: { name: %w[Closed Resolved Declined Approved] }).distinct.count(:id)
+  end
+
   private
 
   def email_domain_must_be_certified

--- a/app/views/home/_product_tasks_show.html.erb
+++ b/app/views/home/_product_tasks_show.html.erb
@@ -16,7 +16,7 @@
           My Open Project
         </p>
         <span class="text-lg sm:text-xl font-bold">
-          <%= current_user.all_open_tickets_for_the_current_user_count %>
+          <%= current_user.all_open_tasks_for_the_current_user_count %>
         </span>
       </div>
     <%# end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -148,14 +148,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_08_073744) do
     t.index ["product_id"], name: "index_banking_types_on_product_id"
   end
 
-  create_table "banking_types_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "product_id", null: false
-    t.uuid "banking_type_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["product_id", "banking_type_id"], name: "index_banking_types_products_on_product_and_banking_type", unique: true
-  end
-
   create_table "boards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "status"
     t.uuid "product_id", null: false
@@ -1269,8 +1261,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_08_073744) do
   add_foreign_key "banking_types", "users", column: "created_by_id"
   add_foreign_key "banking_types", "users", column: "deleted_by_id"
   add_foreign_key "banking_types", "users", column: "modified_by_id"
-  add_foreign_key "banking_types_products", "banking_types"
-  add_foreign_key "banking_types_products", "products"
   add_foreign_key "boards", "products"
   add_foreign_key "boards", "users"
   add_foreign_key "clients", "users"


### PR DESCRIPTION
…play
This pull request updates the way open tasks are counted and displayed for the current user, and removes the `banking_types_products` join table and its associated foreign keys from the database schema. The main changes are grouped by user functionality and database schema cleanup.

**User functionality update:**

* Added a new method `all_open_tasks_for_the_current_user_count` to the `User` model to count open tasks similarly to how open tickets were previously counted.
* Updated the home page partial (`_product_tasks_show.html.erb`) to display the count of open tasks using the new method instead of the previous ticket count.

**Database schema cleanup:**

* Removed the `banking_types_products` join table from `schema.rb`, which previously linked banking types to products.
* Deleted the foreign key constraints associated with the `banking_types_products` table.